### PR TITLE
Fixed user rights bug

### DIFF
--- a/Vocaluxe/Base/Server/CVocaluxeServer.cs
+++ b/Vocaluxe/Base/Server/CVocaluxeServer.cs
@@ -678,9 +678,9 @@ namespace Vocaluxe.Base.Server
             }
 
             //Hide TR_USERROLE_GUEST and TR_USERROLE_NORMAL
-            const EUserRole mask = (EUserRole.TR_USERROLE_GUEST | EUserRole.TR_USERROLE_NORMAL);
+            //const EUserRole mask = (EUserRole.TR_USERROLE_GUEST | EUserRole.TR_USERROLE_NORMAL);
 
-            return (int)(profile.UserRole & ~mask);
+            return (int)(profile.UserRole);
         }
 
         private static void _SetUserRole(int profileId, int userRole)


### PR DESCRIPTION
Normal users can't use the app.
This fix is only a quick fix - we should change TR_USERROLE_GUEST to a number 2^n != 0 
and should ensure that a user can only be TR_USERROLE_GUEST  or TR_USERROLE_NORMAL.
