### PR TITLE
Fix: remote app can't show own profile under some circumstances

### DIFF
--- a/ServerLib/CWebservice.cs
+++ b/ServerLib/CWebservice.cs
@@ -128,7 +128,7 @@ namespace ServerLib
         public SProfileData GetProfile(int profileId)
         {
             Guid sessionKey = _GetSession();
-            if (_CheckRight(EUserRights.ViewOtherProfiles) || CSessionControl.GetUserIdFromSession(sessionKey) == profileId)
+            if (CSessionControl.GetUserIdFromSession(sessionKey) == profileId || _CheckRight(EUserRights.ViewOtherProfiles))
             {
                 if (CServer.GetProfileData == null)
                     return new SProfileData();


### PR DESCRIPTION
_CheckRight would set a access denied code in the respone, if the user does not have the ViewOtherProfiles right .
