### PR TITLE
Linux: enable building on x86 and prepare for packaging

### DIFF
--- a/Vocaluxe/Base/CSettings.cs
+++ b/Vocaluxe/Base/CSettings.cs
@@ -75,6 +75,8 @@ namespace Vocaluxe.Base
 
 #if INSTALLER
         public static readonly string DataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "Vocaluxe");
+#elif LINUX
+        public static readonly string DataFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "Vocaluxe");
 #else
         public static readonly string DataFolder = ProgramFolder;
 #endif

--- a/Vocaluxe/CProgrammHelper.cs
+++ b/Vocaluxe/CProgrammHelper.cs
@@ -96,6 +96,23 @@ namespace Vocaluxe
             return _IsProgramInstalled("Microsoft Visual C++ 2010");
         }
 
+        private static void _EnsureDataFolderExists()
+        {
+            if (!Directory.Exists(CSettings.DataFolder)) {
+                Directory.CreateDirectory(CSettings.DataFolder);
+                // copy default profiles to DataFolder instead of adding ProgramFolder to CConfig.ProfileFolders
+                // because we want to be able to edit them, but might not have permission to write to ProgramFolder
+                string profilePath = Path.Combine(CSettings.DataFolder, CSettings.FolderNameProfiles);
+                Directory.CreateDirectory(profilePath);
+                DirectoryInfo defaultProfileDir = new DirectoryInfo(Path.Combine(CSettings.ProgramFolder, CSettings.FolderNameProfiles));
+                FileInfo[] files = defaultProfileDir.GetFiles();
+                foreach (FileInfo file in files) {
+                    string newPath = Path.Combine(profilePath, file.Name);
+                    file.CopyTo(newPath, false);
+                }
+            }
+        }
+
         public static bool CheckRequirements()
         {
 #if WIN
@@ -135,6 +152,9 @@ namespace Vocaluxe
 #endif
             path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location) + Path.DirectorySeparatorChar + path;
             COSFunctions.AddEnvironmentPath(path);
+#if LINUX
+            _EnsureDataFolderExists();
+#endif
         }
     }
 }

--- a/Vocaluxe/Lib/Input/CHIDAPI.cs
+++ b/Vocaluxe/Lib/Input/CHIDAPI.cs
@@ -47,7 +47,7 @@ namespace Vocaluxe.Lib.Input
 #endif
 
 #if LINUX
-        private const string _HIDApiDll = "libhidapi.so";
+        private const string _HIDApiDll = "libhidapi-libusb.so";
 #endif
 #endif
 

--- a/Vocaluxe/Lib/Video/Acinerella/CAcinerella.cs
+++ b/Vocaluxe/Lib/Video/Acinerella/CAcinerella.cs
@@ -176,7 +176,7 @@ namespace Vocaluxe.Lib.Video.Acinerella
 #endif
 
 #if LINUX
-        private const string _AcDll = "x86/libacinerella.so";
+        private const string _AcDll = "libacinerella.so";
 #endif
 #endif
 

--- a/Vocaluxe/Program.cs
+++ b/Vocaluxe/Program.cs
@@ -85,11 +85,12 @@ namespace Vocaluxe
             {
                 // Init Log
                 CLog.Init();
-                CLog.StartBenchmark("Init Program");
+
                 if (!CProgrammHelper.CheckRequirements())
                     return;
                 CProgrammHelper.Init();
 
+                CLog.StartBenchmark("Init Program");
                 CMain.Init();
                 Application.DoEvents();
 

--- a/makefile
+++ b/makefile
@@ -1,9 +1,10 @@
+ARCH?=$(shell uname -m | sed -e s/i.86/x86/ -e s/x86_64/x64/)
 windowsLibs = Output/gstreamer-sharp.dll Output/glib-sharp.dll
 all:
 	$(MAKE) -C PitchTracker
 	$(MAKE) -C Vocaluxe/Lib/Video/Acinerella
 	rm -f $(windowsLibs)
-	xbuild /property:Platform=x64 /property:Configuration=ReleaseLinux
+	xbuild /property:Platform=$(ARCH) /property:Configuration=ReleaseLinux
 
 clean:
 	xbuild /target:Clean


### PR DESCRIPTION
On GNU/Linux:
* build for x86 if we're on x86
* store config in ~/.config/Vocaluxe instead of in install dir, because we might not have permission to write there if installed as a package