### PR TITLE
PartyMode Challenge: Added an option to not refill jokers after every…

### DIFF
--- a/Output/PartyModes/Challenge.xml
+++ b/Output/PartyModes/Challenge.xml
@@ -8,7 +8,7 @@
     <Folder>Challenge</Folder>
 	<PartyModeFile>CPartyModeChallenge</PartyModeFile>
     <PartyModeVersionMajor>0</PartyModeVersionMajor>
-    <PartyModeVersionMinor>2</PartyModeVersionMinor>
+    <PartyModeVersionMinor>3</PartyModeVersionMinor>
 	<TargetAudience>TR_PARTYMODE_AUDIENCE</TargetAudience>
   </Info>
   <PartyScreens>

--- a/Output/PartyModes/Challenge/Languages/English.xml
+++ b/Output/PartyModes/Challenge/Languages/English.xml
@@ -16,6 +16,7 @@
   <string name="TR_SCREENCONFIG_NUMMICS">Number of mics</string>
   <string name="TR_SCREENCONFIG_NUMROUNDS">Number of rounds</string>
   <string name="TR_SCREENCONFIG_NUMJOKERS">Number of jokers</string>
+  <string name="TR_SCREENCONFIG_REFILLJOKERS">Refill jokers every round</string>
   <string name="TR_SCREENNAMES_TITLE">Challenge Mode: Choose Player</string>
   <string name="TR_SCREENNAMES_BUTTON_RANDOM">Select random</string>
   <string name="TR_SCREENMAIN_TITLE">Challenge Mode: Overview</string>

--- a/Output/PartyModes/Challenge/Themes/Default/Screens/PartyScreenChallengeConfig.xml
+++ b/Output/PartyModes/Challenge/Themes/Default/Screens/PartyScreenChallengeConfig.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>PartyScreenChallengeConfig</ScreenName>
-    <ScreenVersion>2</ScreenVersion>
+    <ScreenVersion>3</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -96,6 +96,20 @@
       <Style>Bold</Style>
       <Font>Outline</Font>
       <Text>TR_SCREENCONFIG_NUMJOKERS</Text>
+    </Text>
+	<Text Name="Text6">
+      <X>75</X>
+      <Y>345</Y>
+      <Z>0</Z>
+      <H>27</H>
+      <MaxW>0</MaxW>
+      <Color Name="StaticColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENCONFIG_REFILLJOKERS</Text>
     </Text>
   </Texts>
   <Buttons>
@@ -340,6 +354,48 @@
       <TextFont>Outline</TextFont>
       <TextStyle>Bold</TextStyle>
       <NumVisible>10</NumVisible>
+    </SelectSlide>
+	<SelectSlide Name="SelectSlideRefillJokers">
+      <Skin/>
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>500</X>
+        <Y>340</Y>
+        <W>700</W>
+        <H>50</H>
+        <Z>0</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>505</X>
+        <Y>345</Y>
+        <W>40</W>
+        <H>40</H>
+        <Z>0</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1170</X>
+        <Y>345</Y>
+        <W>40</W>
+        <H>40</H>
+        <Z>0</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColor" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>27</TextH>
+      <TextRelativeX>50</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>205.33</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>2</NumVisible>
     </SelectSlide>
   </SelectSlides>
   <SingNotes />

--- a/PartyModes/PartyModeChallenge/CPartyModeChallenge.cs
+++ b/PartyModes/PartyModeChallenge/CPartyModeChallenge.cs
@@ -114,6 +114,8 @@ namespace VocaluxeLib.PartyModes.Challenge
             public int NumPlayerAtOnce;
             public int NumRounds;
             public int NumJokers;
+            public bool RefillJokers;
+            public int[] Jokers;
             public List<int> ProfileIDs;
 
             public CChallengeRounds Rounds;
@@ -148,7 +150,7 @@ namespace VocaluxeLib.PartyModes.Challenge
             _ScreenSongOptions.Sorting.SearchActive = false;
             _ScreenSongOptions.Sorting.DuetOptions = EDuetOptions.NoDuets;
 
-            GameData = new SData {NumPlayer = 4, NumPlayerAtOnce = 2, NumRounds = 12, NumJokers = 5, CurrentRoundNr = 1, ProfileIDs = new List<int>(), CatSongIndices = null, Results = null};
+            GameData = new SData {NumPlayer = 4, NumPlayerAtOnce = 2, NumRounds = 12, NumJokers = 5, RefillJokers = true, CurrentRoundNr = 1, ProfileIDs = new List<int>(), CatSongIndices = null, Results = null};
         }
 
         public override bool Init()
@@ -214,6 +216,7 @@ namespace VocaluxeLib.PartyModes.Challenge
                     GameData.ResultTable = new List<CResultTableRow>();
                     GameData.Rounds = new CChallengeRounds(GameData.NumRounds, GameData.NumPlayer, GameData.NumPlayerAtOnce);
                     GameData.CurrentRoundNr = 1;
+                    GameData.Jokers = null;
                     break;
                 case EStage.Main:
                     _Stage = EStage.Singing;
@@ -321,6 +324,11 @@ namespace VocaluxeLib.PartyModes.Challenge
             if (teamNr >= _ScreenSongOptions.Selection.NumJokers.Length)
                 return;
 
+            if (!GameData.RefillJokers)
+            {
+                CRound round = GameData.Rounds[GameData.CurrentRoundNr - 1];
+                GameData.Jokers[round.Players[teamNr]]--;
+            }
             _ScreenSongOptions.Selection.NumJokers[teamNr]--;
             _ScreenSongOptions.Selection.RandomOnly = true;
             _ScreenSongOptions.Selection.CategoryChangeAllowed = false;
@@ -375,9 +383,27 @@ namespace VocaluxeLib.PartyModes.Challenge
         private void _SetNumJokers()
         {
             int[] jokers = new int[GameData.NumPlayerAtOnce];
-            for (int i = 0; i < jokers.Length; i++)
-                jokers[i] = GameData.NumJokers;
-
+            if (GameData.RefillJokers)
+            {                
+                for (int i = 0; i < jokers.Length; i++)
+                    jokers[i] = GameData.NumJokers;                
+            }
+            else
+            {
+                if (GameData.Jokers == null)
+                {
+                    GameData.Jokers = new int[GameData.NumPlayer];
+                    for (int i = 0; i < GameData.ProfileIDs.Count; i++)
+                    {
+                        GameData.Jokers[i] = GameData.NumJokers;
+                    }
+                }
+                CRound round = GameData.Rounds[GameData.CurrentRoundNr - 1];
+                for (int i = 0; i < GameData.NumPlayerAtOnce; i++)
+                {
+                    jokers[i] = GameData.Jokers[round.Players[i]];
+                }
+            }
             _ScreenSongOptions.Selection.NumJokers = jokers;
         }
 

--- a/PartyModes/PartyModeChallenge/CPartyScreenChallengeConfig.cs
+++ b/PartyModes/PartyModeChallenge/CPartyScreenChallengeConfig.cs
@@ -27,13 +27,14 @@ namespace VocaluxeLib.PartyModes.Challenge
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 2; }
+            get { return 3; }
         }
 
         private const string _SelectSlideNumPlayers = "SelectSlideNumPlayers";
         private const string _SelectSlideNumMics = "SelectSlideNumMics";
         private const string _SelectSlideNumRounds = "SelectSlideNumRounds";
         private const string _SelectSlideNumJokers = "SelectSlideNumJokers";
+        private const string _SelectSlideRefillJokers = "SelectSlideRefillJokers";
         private const string _ButtonNext = "ButtonNext";
         private const string _ButtonBack = "ButtonBack";
 
@@ -44,7 +45,7 @@ namespace VocaluxeLib.PartyModes.Challenge
         {
             base.Init();
 
-            _ThemeSelectSlides = new string[] {_SelectSlideNumPlayers, _SelectSlideNumMics, _SelectSlideNumRounds, _SelectSlideNumJokers};
+            _ThemeSelectSlides = new string[] { _SelectSlideNumPlayers, _SelectSlideNumMics, _SelectSlideNumRounds, _SelectSlideNumJokers, _SelectSlideRefillJokers };
             _ThemeButtons = new string[] {_ButtonNext, _ButtonBack};
         }
 
@@ -132,6 +133,12 @@ namespace VocaluxeLib.PartyModes.Challenge
             }
             _SelectSlides[_SelectSlideNumJokers].SelectedValue = "5";
 
+            //build joker config slide
+            _SelectSlides[_SelectSlideRefillJokers].Clear();
+            _SelectSlides[_SelectSlideRefillJokers].AddValue(CBase.Language.Translate("TR_BUTTON_NO", PartyModeID));
+            _SelectSlides[_SelectSlideRefillJokers].AddValue(CBase.Language.Translate("TR_BUTTON_YES", PartyModeID));
+            _SelectSlides[_SelectSlideRefillJokers].SelectLastValue();
+
             _UpdateMicsAtOnce();
             _SetRoundSteps();
             _UpdateSlideRounds();
@@ -145,6 +152,7 @@ namespace VocaluxeLib.PartyModes.Challenge
             _PartyMode.GameData.NumPlayerAtOnce = _SelectSlides[_SelectSlideNumMics].Selection + _PartyMode.MinPlayers;
             _PartyMode.GameData.NumRounds = (_SelectSlides[_SelectSlideNumRounds].Selection + 1) * _RoundSteps;
             _PartyMode.GameData.NumJokers = _SelectSlides[_SelectSlideNumJokers].Selection + 1;
+            _PartyMode.GameData.RefillJokers = (_SelectSlides[_SelectSlideRefillJokers].Selection == 1) ? true : false;
 
             _UpdateMicsAtOnce();
             _SetRoundSteps();


### PR DESCRIPTION
… song

Players can now choose between refilling the jokers every song and save
the amount of jokers (e.g. 5 Jokers per Player for the whole PartyMode).


This commit (https://github.com/z3ro01/Vocaluxe/commit/50c19ff85df3e459e2d36c3b8d50aff6cd1a549e) should be merged before accepting this pull request. Without this Fix the jokers don't reset properly or the game crashes.
