### PR TITLE
Wiimote single thread experiment

### DIFF
--- a/Vocaluxe/Lib/Input/WiiMote/WiiMoteLib.cs
+++ b/Vocaluxe/Lib/Input/WiiMote/WiiMoteLib.cs
@@ -198,7 +198,8 @@ namespace Vocaluxe.Lib.Input.WiiMote
             {
                 _Connected = value;
 
-                WiiMoteConnectionChanged?.Invoke(this, new CWiiMoteConnectionChangedEventArgs(value));
+                if (WiiMoteConnectionChanged != null)
+                    WiiMoteConnectionChanged.Invoke(this, new CWiiMoteConnectionChangedEventArgs(value));
             }
         }
 

--- a/Vocaluxe/Lib/Input/WiiMote/WiiMoteLib.cs
+++ b/Vocaluxe/Lib/Input/WiiMote/WiiMoteLib.cs
@@ -135,6 +135,15 @@ namespace Vocaluxe.Lib.Input.WiiMote
             WiiMoteState = ws;
         }
     }
+    public class CWiiMoteConnectionChangedEventArgs : EventArgs
+    {
+        public readonly bool Connected;
+
+        public CWiiMoteConnectionChangedEventArgs(bool connected)
+        {
+            Connected = connected;
+        }
+    }
     #endregion Events
 
     public sealed class CWiiMoteLib
@@ -181,11 +190,22 @@ namespace Vocaluxe.Lib.Input.WiiMote
         private Thread _Reader;
         private readonly bool _Error;
 
-        public bool Connected { get; private set; }
+        private bool _Connected;
+        public bool Connected
+        {
+            get { return _Connected; }
+            private set
+            {
+                _Connected = value;
+
+                WiiMoteConnectionChanged?.Invoke(this, new CWiiMoteConnectionChangedEventArgs(value));
+            }
+        }
 
         private readonly CWiiMoteStatus _WiiMoteState = new CWiiMoteStatus();
         private readonly AutoResetEvent _ReadDone = new AutoResetEvent(false);
         public event EventHandler<CWiiMoteChangedEventArgs> WiiMoteChanged;
+        public event EventHandler<CWiiMoteConnectionChangedEventArgs> WiiMoteConnectionChanged;
 
         #region Interface
         public CWiiMoteLib()
@@ -326,6 +346,7 @@ namespace Vocaluxe.Lib.Input.WiiMote
                     if (bytesRead == -1)
                     {
                         Connected = false; //Disconnected
+                        Connect();
                         break;
                     }
                 }
@@ -339,7 +360,7 @@ namespace Vocaluxe.Lib.Input.WiiMote
                 if (bytesRead > 0 && _ParseInputReport(buff))
                 {
                     if (WiiMoteChanged != null)
-                        WiiMoteChanged(this, new CWiiMoteChangedEventArgs(_WiiMoteState));
+                        WiiMoteChanged.Invoke(this, new CWiiMoteChangedEventArgs(_WiiMoteState));
                 }
                 Thread.Sleep(5);
             }


### PR DESCRIPTION
Removes one out of the threads from the Wiimote handler.
One thread is just waiting that the other changes something -> introduced an event

I can not test this, but I think @Shiroi has tested it.
@Shiroi: can you please confirm...