### PR TITLE
Mod: prefer shipped gstreamer over an installed version (closes #199)

### DIFF
--- a/Vocaluxe/Lib/Sound/Playback/GstreamerSharp/CGstreamerSharpAudio.cs
+++ b/Vocaluxe/Lib/Sound/Playback/GstreamerSharp/CGstreamerSharpAudio.cs
@@ -35,26 +35,29 @@ namespace Vocaluxe.Lib.Sound.Playback.GstreamerSharp
 #if ARCH_X64
             const string varName = "GSTREAMER_1_0_ROOT_X86_64";
 #endif
-            string gstreamerEnvVar = Environment.GetEnvironmentVariable(varName, EnvironmentVariableTarget.User);
             string dllDirectory;
-            if (gstreamerEnvVar == null || !Directory.Exists(gstreamerEnvVar))
-            {
+
 #if ARCH_X86
-                dllDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "libs\\unmanaged\\gstreamer86\\bin\\");
+            dllDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "libs\\unmanaged\\gstreamer86\\bin\\");
 #endif
 #if ARCH_X64
-                dllDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "libs\\unmanaged\\gstreamer64\\bin\\");
+            dllDirectory = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "libs\\unmanaged\\gstreamer64\\bin\\");
 #endif
-                if (!Directory.Exists(dllDirectory))
+            if (!Directory.Exists(dllDirectory))
+            {
+                string gstreamerEnvVar = Environment.GetEnvironmentVariable(varName, EnvironmentVariableTarget.User);
+
+                if (gstreamerEnvVar == null || !Directory.Exists(gstreamerEnvVar))
                 {
                     CLog.LogError("Gstreamer not found! Make sure you installed it correctly and if it set the environment variable '" + varName + "'!", true);
                     return false;
                 }
+                else
+                {
+                    dllDirectory = gstreamerEnvVar + "bin\\";
+                }
             }
-            else
-            {
-                dllDirectory = gstreamerEnvVar + "bin\\";
-            }
+           
             
             COSFunctions.AddEnvironmentPath(dllDirectory);
             #endif


### PR DESCRIPTION
should reduce confusion if some users have an old version or a version with missing plugins installed.
Those who really want to use a different version of gstreamer (although I don't see the reason) will know how delete the folder of the shipped version.

If I interpret @derivator 's https://github.com/Vocaluxe/Vocaluxe/issues/199#issuecomment-188369766 right, the Linux version is not affected.