### PR TITLE
"Select random" in party mode name selection broken

### DIFF
--- a/VocaluxeLib/Menu/CMenuPartyNameSelection.cs
+++ b/VocaluxeLib/Menu/CMenuPartyNameSelection.cs
@@ -774,7 +774,8 @@ namespace VocaluxeLib.Menu
                 for (int p = 0; p < _NumPlayerTeams[t]; p++)
                 {
                     int profileID = _NameSelections[_NameSelection].GetRandomUnusedProfile();
-                    _AddPlayer(t, profileID);
+                    if(profileID >= 0) //only add valid profiles
+                        _AddPlayer(t, profileID);
                 }
             }
         }

--- a/VocaluxeLib/Menu/CMenuPartyNameSelection.cs
+++ b/VocaluxeLib/Menu/CMenuPartyNameSelection.cs
@@ -618,6 +618,7 @@ namespace VocaluxeLib.Menu
                 _UpdatePlayerSlide();
             }
             _UpdateButtonState();
+            _UpdateNextButtonVisibility();
         }
 
         public void DecreasePlayerNum(int team)
@@ -633,6 +634,7 @@ namespace VocaluxeLib.Menu
                 _UpdatePlayerSlide();
             }
             _UpdateButtonState();
+            _UpdateNextButtonVisibility();
         }
 
         #region private methods

--- a/VocaluxeLib/Menu/CNameSelection.cs
+++ b/VocaluxeLib/Menu/CNameSelection.cs
@@ -465,23 +465,11 @@ namespace VocaluxeLib.Menu
 
         public int GetRandomUnusedProfile()
         {
-            int id = -1;
-
             if (_VisibleProfiles.Count == 0)
-                return id;
+                return -1;
 
-            if (_VisibleProfiles.Count == _UsedProfiles.Count)
-                return id;
-
-            while (id == -1)
-            {
-                int rand = CBase.Game.GetRandom(_VisibleProfiles.Count);
-                if (_UsedProfiles.Contains(_VisibleProfiles[rand]))
-                    continue;
-                id = _VisibleProfiles[rand];
-            }
-
-            return id;
+            int rand = CBase.Game.GetRandom(_VisibleProfiles.Count);
+            return _VisibleProfiles[rand];
         }
 
         private void _PrepareTiles()


### PR DESCRIPTION
Currently if the number of visible profiles matches the number of used profiles or if there are more slots than usable profiles, an invalid profile with id -1 is selected if you click "Select random". I think the code `if (_VisibleProfiles.Count == _UsedProfiles.Count)` was trying to check if all profiles are already in use, but the way I understand `_UpdateVisibleProfiles()`, `_VisibleProfiles` already contains only the actually visible (=selectable profiles). Am I misunderstanding something @flokuep ? This way seems to work correctly.