### PR TITLE
Support the versioning scheme

### DIFF
--- a/.appveyor/gitDescribe.ps1
+++ b/.appveyor/gitDescribe.ps1
@@ -1,9 +1,3 @@
-if($Env:APPVEYOR_PULL_REQUEST_NUMBER)
-{
-	$Env:VersionTag = "PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
-	Return $Env:VersionTag
-}
-
 $currentCommitSha = $Env:CurrentCommitSha
 $githubRepoApiUri = $Env:githubRepoApiUri #"https://api.github.com/repos/:user/:repo/"
 $Env:VersionTag = ""
@@ -59,5 +53,12 @@ if(!$latestTag){
 	Return ;
 }
 
-$Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-g$($currentCommitSha.Substring(0,7))"
+if($Env:APPVEYOR_PULL_REQUEST_NUMBER)
+{
+	$Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
+}
+else
+{
+    $Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-g$($currentCommitSha.Substring(0,7))"
+}
 Return $Env:VersionTag

--- a/.appveyor/gitDescribe.ps1
+++ b/.appveyor/gitDescribe.ps1
@@ -1,6 +1,6 @@
 if($Env:APPVEYOR_PULL_REQUEST_NUMBER)
 {
-	$Env:VersionTag = "0.0.0.pr-na-PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
+	$Env:VersionTag = "0.0.0-na-PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
 	Return $Env:VersionTag
 }
 

--- a/.appveyor/gitDescribe.ps1
+++ b/.appveyor/gitDescribe.ps1
@@ -1,3 +1,9 @@
+if($Env:APPVEYOR_PULL_REQUEST_NUMBER)
+{
+	$Env:VersionTag = "0.0.0.pr-na-PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
+	Return $Env:VersionTag
+}
+
 $currentCommitSha = $Env:CurrentCommitSha
 $githubRepoApiUri = $Env:githubRepoApiUri #"https://api.github.com/repos/:user/:repo/"
 $Env:VersionTag = ""
@@ -53,12 +59,5 @@ if(!$latestTag){
 	Return ;
 }
 
-if($Env:APPVEYOR_PULL_REQUEST_NUMBER)
-{
-	$Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-PR_$Env:APPVEYOR_PULL_REQUEST_NUMBER"
-}
-else
-{
-    $Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-g$($currentCommitSha.Substring(0,7))"
-}
+$Env:VersionTag = "$($latestTag.tag)-$($latestTag.dist)-g$($currentCommitSha.Substring(0,7))"
 Return $Env:VersionTag

--- a/Vocaluxe/Base/CSettings.cs
+++ b/Vocaluxe/Base/CSettings.cs
@@ -18,6 +18,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Windows.Forms;
 using VocaluxeLib;
@@ -53,10 +54,44 @@ namespace Vocaluxe.Base
         public static EProgramState ProgramState = EProgramState.Start;
 
         //Adjusting of programName and version now in the assembly config.
-        //I'd use the major and minor for Main releases, build number for every public release and revision for every bugfix version without any features
-        private const string _ProgramCodeName = "Shining Heaven";
+        private static readonly Dictionary<string,string> _CodeNames = new Dictionary<string, string>()
+        {
+            {"0.3.", "Shining Heaven"},
+            {"0.4.", "Blue Sunrise"}
+        }; 
 
-        public const ERevision VersionRevision = ERevision.Beta;
+        private static string _ProgramCodeName
+        {
+            get
+            {
+                var versionParts = Application.ProductVersion.Split('.');
+                string name;
+                _CodeNames.TryGetValue($"{versionParts[0]}.{versionParts[1]}.", out name);
+                if (name != null)
+                    return name;
+                return "Unnamed Version";
+            }
+        }
+
+        public static ERevision VersionRevision
+        {
+            get
+            {
+                if (_Version.ToLower().Contains("alpha"))
+                {
+                    return ERevision.Alpha;
+                }
+                if (_Version.ToLower().Contains("beta"))
+                {
+                    return ERevision.Beta;
+                }
+                if (_Version.ToLower().Contains("rc"))
+                {
+                    return ERevision.RC;
+                }
+                return ERevision.Release;
+            }
+        }
 
         public const int DatabaseHighscoreVersion = 3;
         public const int DatabaseCoverVersion = 1;
@@ -177,8 +212,7 @@ namespace Vocaluxe.Base
         {
             get
             {
-                Version v = _Assembly.Version;
-                return "v" + v.Major + "." + v.Minor + "." + v.Build;
+                return Application.ProductVersion.Split('-').First();
             }
         }
 
@@ -186,10 +220,8 @@ namespace Vocaluxe.Base
         {
             string version = _Version + " (" + _Arch + ")";
 
-            // ReSharper disable ConditionIsAlwaysTrueOrFalse
             if (VersionRevision != ERevision.Release)
             {
-                // ReSharper restore ConditionIsAlwaysTrueOrFalse
                 string gitversion = Application.ProductVersion;
                 version += " " + _GetVersionStatus() + String.Format(" ({0})", gitversion);
             }
@@ -200,10 +232,8 @@ namespace Vocaluxe.Base
         public static string GetFullVersionText()
         {
             string version = ProgramName;
-
-            // ReSharper disable ConditionIsAlwaysTrueOrFalse
+            
             if (_ProgramCodeName != "")
-                // ReSharper restore ConditionIsAlwaysTrueOrFalse
                 version += " \"" + _ProgramCodeName + "\"";
 
             return version + " " + _GetVersionText();
@@ -211,11 +241,9 @@ namespace Vocaluxe.Base
 
         private static string _GetVersionStatus()
         {
-            string result;
+            string result = "";
 
-            // ReSharper disable ConditionIsAlwaysTrueOrFalse
             if (VersionRevision != ERevision.Release)
-                // ReSharper restore ConditionIsAlwaysTrueOrFalse
                 result = Enum.GetName(typeof(ERevision), VersionRevision);
 
             return result;

--- a/Vocaluxe/Base/CSettings.cs
+++ b/Vocaluxe/Base/CSettings.cs
@@ -220,9 +220,10 @@ namespace Vocaluxe.Base
         {
             string version = _Version + " (" + _Arch + ")";
 
-            if (VersionRevision != ERevision.Release)
+            string gitversion = Application.ProductVersion;
+
+            if (VersionRevision != ERevision.Release || gitversion.Split('-')[1] != "0")
             {
-                string gitversion = Application.ProductVersion;
                 version += " " + _GetVersionStatus() + String.Format(" ({0})", gitversion);
             }
 

--- a/Vocaluxe/Linux/Build/PostBuildEvent.sh
+++ b/Vocaluxe/Linux/Build/PostBuildEvent.sh
@@ -2,4 +2,6 @@
 PROJECT=$1
 cd $PROJECT
 sed -i -r -e 's/AssemblyInformationalVersion\(".*?"\)/AssemblyInformationalVersion("GITVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyVersion\(".*?"\)/AssemblyVersion("SHORTVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyFileVersion\(".*?"\)/AssemblyFileVersion("SHORTVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
 sed -i -e 's/var matchingServerVersion = "";/var matchingServerVersion = "'$(git describe --long)'";/' $PROJECT/../Output/Website/js/main.js

--- a/Vocaluxe/Linux/Build/PreBuildEvent.sh
+++ b/Vocaluxe/Linux/Build/PreBuildEvent.sh
@@ -2,3 +2,5 @@
 PROJECT=$1
 cd $PROJECT
 sed -i -e s/GITVERSION/$(git describe --long)/ $PROJECT/Properties/AssemblyInfo.cs
+shortv=$(git describe --abbrev=0 | sed -e 's/alpha/0/' -e 's/beta/1/' -e 's/rc/2/')
+sed -i -e s/SHORTVERSION/${shortv}/ $PROJECT/Properties/AssemblyInfo.cs

--- a/Vocaluxe/Properties/AssemblyInfo.cs
+++ b/Vocaluxe/Properties/AssemblyInfo.cs
@@ -27,7 +27,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("Vocaluxe")]
-[assembly: AssemblyCopyright("Copyright ©  2013")]
+[assembly: AssemblyCopyright("Copyright © 2016")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -49,6 +49,6 @@ using System.Runtime.InteropServices;
 //      Revision
 //
 
-[assembly: AssemblyVersion("0.3.0.83")]
-[assembly: AssemblyFileVersion("0.3.0.83")]
+[assembly: AssemblyVersion("SHORTVERSION")]
+[assembly: AssemblyFileVersion("SHORTVERSION")]
 [assembly: AssemblyInformationalVersion("GITVERSION")]

--- a/Vocaluxe/Screens/CScreenMain.cs
+++ b/Vocaluxe/Screens/CScreenMain.cs
@@ -54,9 +54,7 @@ namespace Vocaluxe.Screens
             base.LoadTheme(xmlPath);
 
             _Texts[_TextRelease].Text = CSettings.GetFullVersionText();
-            // ReSharper disable ConditionIsAlwaysTrueOrFalse
-            _Texts[_TextRelease].Visible = CSettings.VersionRevision != ERevision.Release;
-            // ReSharper restore ConditionIsAlwaysTrueOrFalse
+            _Texts[_TextRelease].Visible = true;
             _Statics[_StaticWarningProfiles].Visible = false;
             _Texts[_TextWarningProfiles].Visible = false;
         }

--- a/Vocaluxe/Vocaluxe.csproj
+++ b/Vocaluxe/Vocaluxe.csproj
@@ -479,12 +479,12 @@
   <PropertyGroup>
     <PostBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">xcopy /E /D /Y "$(ProjectDir)\Website" "$(SolutionDir)\PhoneGap"
 powershell -command "if($Env:GIT_VERSION_TAG) {$version = $Env:GIT_VERSION_TAG;} else {$version = git describe --long;}(Get-Content -Encoding UTF8 '$(ProjectDir)..\Output\Website\js\main.js') |  Foreach-Object {$_ -replace '(?&lt;=var *matchingServerVersion * = *\")\w*(?=\" *;)', "$version"} | Set-Content -Encoding UTF8 '$(ProjectDir)..\Output\Website\js\main.js'"
-powershell -command "(Get-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs') | Foreach-Object {$_ -replace '(?&lt;=AssemblyInformationalVersion\()(.*)(?=\))', '\"GITVERSION\"'} | Set-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs'"</PostBuildEvent>
+powershell -command "(Get-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs') | Foreach-Object {$_ -replace '(?&lt;=AssemblyInformationalVersion\(\").*(?=\")', 'GITVERSION'} | Foreach-Object {$_ -replace '(?&lt;=(AssemblyVersion|AssemblyFileVersion)\(\").*(?=\")', 'SHORTVERSION'} | Set-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs' "</PostBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">cp -ruT "$(ProjectDir)Website" "$(SolutionDir)/PhoneGap"</PostBuildEvent>
     <PostBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">$(ProjectDir)Linux/Build/PostBuildEvent.sh $(ProjectDir)</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
-    <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">powershell -command "if($Env:GIT_VERSION_TAG) {$version = $Env:GIT_VERSION_TAG;} else {$version = git describe --long;} (Get-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs') | Foreach-Object {$_ -replace 'GITVERSION', $version} | Set-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs'"</PreBuildEvent>
+    <PreBuildEvent Condition=" '$(OS)' == 'Windows_NT' ">powershell -command " if($Env:GIT_VERSION_TAG) {$version = $Env:GIT_VERSION_TAG;} else {$version = git describe --long;} (Get-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs') | Foreach-Object {$_ -replace '(?&lt;=AssemblyInformationalVersion\(\").*(?=\")', $version} | Foreach-Object {$_ -replace '(?&lt;=(AssemblyVersion|AssemblyFileVersion)\(\").*(?=\")', $version.Split('-')[0].replace('alpha','0').replace('beta','1').replace('rc','2')} | Foreach-Object {$_ -replace '(?&lt;=AssemblyCopyright\(\".*)[0-9]+(?=\")', (Get-Date).Year} | Set-Content -Encoding UTF8 '$(ProjectDir)Properties\AssemblyInfo.cs' "</PreBuildEvent>
     <PreBuildEvent Condition=" '$(OS)' != 'Windows_NT' ">$(ProjectDir)Linux/Build/PreBuildEvent.sh $(ProjectDir)</PreBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
e.g. `0.4.0.beta1`

- Mod: New versioning scheme including type if type!=release
- Mod: Show the same version tag everywhere
- Mod: Automatically determinate release type depending on the new version-tag
- Mod: Automatically determinate CodeName
- Mod: Adjusted pre-/post-build scripts for Windows and Linux
- Add: Code-name for the 0.4. releases 
"Blue Sunrise" - we can change that if you have a better idea 😉
First I thought about names of singing birds but the last release was "Shining Heaven".