### PR TITLE
Fixed: $(APPVEYOR_REPO_COMMIT) tag is missing in some releases

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,7 @@ deploy:
 - provider: GitHub
   tag: $(APPVEYOR_REPO_TAG_NAME)
   release: $(APPVEYOR_REPO_TAG_NAME)
-  description: 
+  description: $(APPVEYOR_REPO_COMMIT)
   auth_token:
     secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
   artifact: ReleaseZip


### PR DESCRIPTION
Adds the commit id to the description - you can change release description later but keep that id somewhere.

-> with this ist should work with beta2

#306 