### PR TITLE
PortAudio close-stream-handling

### DIFF
--- a/Vocaluxe/Lib/Sound/CPortAudioHandle.cs
+++ b/Vocaluxe/Lib/Sound/CPortAudioHandle.cs
@@ -79,7 +79,16 @@ namespace Vocaluxe.Lib.Sound
                 Debug.Assert(_RefCount > 0);
                 _RefCount--;
                 if (_RefCount == 0)
-                    PortAudio.Pa_Terminate();
+                {
+                    try
+                    {
+                        PortAudio.Pa_Terminate();
+                    }
+                    catch (Exception ex)
+                    {
+                        CLog.LogError(errorText: $"Error disposing PortAudio: {ex.Message}", e: ex);
+                    }
+                }
                 _Disposed = true;
             }
         }
@@ -164,7 +173,14 @@ namespace Vocaluxe.Lib.Sound
                 if (_Disposed)
                     throw new ObjectDisposedException("PortAudioHandle already disposed");
 
-                PortAudio.Pa_CloseStream(stream);
+                try
+                {
+                    PortAudio.Pa_CloseStream(stream);
+                }
+                catch (Exception ex)
+                {
+                    CLog.LogError(errorText:$"Error closing stream: {ex.Message}", e:ex);
+                }
                 _Streams.Remove(stream);
             }
         }

--- a/Vocaluxe/Lib/Sound/CPortAudioHandle.cs
+++ b/Vocaluxe/Lib/Sound/CPortAudioHandle.cs
@@ -74,12 +74,14 @@ namespace Vocaluxe.Lib.Sound
             }
             lock (_Mutex)
             {
+                if (_Disposed)
+                    return;
                 Debug.Assert(_RefCount > 0);
                 _RefCount--;
                 if (_RefCount == 0)
                     PortAudio.Pa_Terminate();
+                _Disposed = true;
             }
-            _Disposed = true;
         }
 
         public void Dispose()
@@ -100,11 +102,11 @@ namespace Vocaluxe.Lib.Sound
                                             double sampleRate, uint framesPerBuffer, PortAudio.PaStreamFlags streamFlags,
                                             PortAudio.PaStreamCallbackDelegate streamCallback, IntPtr userData)
         {
-            if (_Disposed)
-                throw new ObjectDisposedException("PortAudioHandle already disposed");
-
             lock (_Mutex)
             {
+                if (_Disposed)
+                    throw new ObjectDisposedException("PortAudioHandle already disposed");
+
                 PortAudio.PaError res = PortAudio.Pa_OpenStream(out stream, ref inputParameters, ref outputParameters, sampleRate, framesPerBuffer, streamFlags, streamCallback,
                                                                 userData);
                 if (res == PortAudio.PaError.paNoError)
@@ -157,11 +159,11 @@ namespace Vocaluxe.Lib.Sound
 
         public void CloseStream(IntPtr stream)
         {
-            if (_Disposed)
-                throw new ObjectDisposedException("PortAudioHandle already disposed");
-
             lock (_Mutex)
             {
+                if (_Disposed)
+                    throw new ObjectDisposedException("PortAudioHandle already disposed");
+
                 PortAudio.Pa_CloseStream(stream);
                 _Streams.Remove(stream);
             }


### PR DESCRIPTION
Moved some checks to the code within the mutex.

Should fix the problem in #320 

Should be merged in `master` (to fix the bug in 4.0) and `develop`.