### PR TITLE
Fix V3127

### DIFF
--- a/VocaluxeLib/Menu/SingNotes/CSingNotes.cs
+++ b/VocaluxeLib/Menu/SingNotes/CSingNotes.cs
@@ -114,7 +114,7 @@ namespace VocaluxeLib.Menu.SingNotes
             else
             {
                 _Rect.X = PlayerNotes.Select(bp => bp.Rect.X).Min();
-                _Rect.Y = PlayerNotes.Select(bp => bp.Rect.X).Min();
+                _Rect.Y = PlayerNotes.Select(bp => bp.Rect.Y).Min();
                 _Rect.Right = PlayerNotes.Select(bp => bp.Rect.Right).Max();
                 _Rect.Bottom = PlayerNotes.Select(bp => bp.Rect.Bottom).Max();
                 _Rect.Z = PlayerNotes.Select(bp => bp.Rect.Z).Average();


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

* Two similar code fragments were found. Perhaps, this is a typo and 'Y' variable should be used instead of 'X' VocaluxeLib CSingNotes.cs 117