### PR TITLE
Sort Profiles by Player Name

### DIFF
--- a/Vocaluxe/Base/CProfiles.cs
+++ b/Vocaluxe/Base/CProfiles.cs
@@ -19,6 +19,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.IO;
+using System.Text.RegularExpressions;
 using VocaluxeLib;
 using VocaluxeLib.Draw;
 using VocaluxeLib.Profile;
@@ -300,7 +301,7 @@ namespace Vocaluxe.Base
                 return new CProfile[0];
 
             var list = new List<CProfile>(_Profiles.Values);
-            list.Sort(_CompareByPlayerName);
+            list.Sort(_AlphaNumericCompareByPlayerName);
             return list.ToArray();
         }
 
@@ -646,9 +647,14 @@ namespace Vocaluxe.Base
             _ProfilesChanged = true;
         }
 
-        private static int _CompareByPlayerName(CProfile a, CProfile b)
+        private static int _AlphaNumericCompareByPlayerName(CProfile a, CProfile b)
         {
-            return String.CompareOrdinal(a.PlayerName, b.PlayerName);
+            return _PadNumbersInString(a.PlayerName).CompareTo(_PadNumbersInString(b.PlayerName));
+        }
+
+        private static string _PadNumbersInString(string text)
+        {
+            return Regex.Replace(text, "[0-9]+", match => match.Value.PadLeft(4, '0'));
         }
 
         public static CAvatar GetAvatarByFilename(string fileName)


### PR DESCRIPTION
Something that resembles natural sorting by player name (for names with
numbers up to 9999) of the profiles.

I'm not sure what was going wrong with the original sort, but it didn't seem to work.

What do you think?

Should the length of "supported numbers" be configurable in config.xml?

Is there a better solution for natural sorting?