### PR TITLE
Fix Lost Profile Bug in Player Selection

### DIFF
--- a/Vocaluxe/Screens/CScreenNames.cs
+++ b/Vocaluxe/Screens/CScreenNames.cs
@@ -669,6 +669,7 @@ namespace Vocaluxe.Screens
                     _Texts["TextPlayer" + i].Visible = false;
                     _Equalizers["EqualizerPlayer" + i].Visible = false;
                     _SelectSlides["SelectSlideDuetPlayer" + i].Visible = false;
+                    _ResetPlayerSelection(i - 1);
                 }
             }
             CConfig.SaveConfig();


### PR DESCRIPTION
Non-guest profiles assigned to player numbers higher than current amount of players were left as already selected and thus couldn't be selected anymore.

Now the player numbers that are higher than the totals will be cleared and the assigned profiles put back to the pool of profiles to select from.

New profiles will have to be selected if the player amount is increased.