### PR TITLE
Meaningless "Could not query position" messages in the log

### DIFF
--- a/Vocaluxe/Lib/Sound/Playback/GstreamerSharp/CGstreamerSharpAudioStream.cs
+++ b/Vocaluxe/Lib/Sound/Playback/GstreamerSharp/CGstreamerSharpAudioStream.cs
@@ -70,14 +70,20 @@ namespace Vocaluxe.Lib.Sound.Playback.GstreamerSharp
         {
             get
             {
-                if (_Element != null)
+                
+                if (_Element == null || (_Element.CurrentState == State.Paused && _Element.PendingState != State.VoidPending))
                 {
-                    long position;
-                    if (!_Element.QueryPosition(Format.Time, out position))
-                        CLog.LogError("Could not query position");
-                    else
-                        _Position = ((float)position / Constants.SECOND);
+                    return _Position;
                 }
+                    
+                    
+                long position;
+                if (!_Element.QueryPosition(Format.Time, out position))
+                    CLog.LogError("Could not query position");
+                else
+                    _Position = ((float)position / Constants.SECOND);
+                    
+                    
                 return _Position;
             }
             set


### PR DESCRIPTION
I investigated on this problem and for me the are caused during (preview-)video-loading.
gst is just not ready to fulfill the position query.

**Change**: If the pipeline is currently changing the state, we not longer query the position, but answer with the last known (`0` at the beginning). 