### PR TITLE
Distribute debug symbols with the releases 

### DIFF
--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -1,4 +1,4 @@
-choco install gitlink --version 3.2.0-unstable0014 --pre --no-progress --limit-output
+choco install gitlink --version 3.1.0-unstable0017 --pre --no-progress --limit-output
 
 Get-ChildItem -Recurse "*.pdb" | %{
     If ($_.Fullname -contains 'PitchTracker.pdb'){

--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -1,10 +1,10 @@
-choco install gitlink --version 3.2.0-unstable0014 --pre
+choco install gitlink --version 3.2.0-unstable0014 --pre --no-progress --limit-output
 
 Get-ChildItem -Recurse "*.pdb" | %{
     If ($_.Fullname -contains 'PitchTracker.pdb'){
-        gitlink -u "https://github.com/$($Env:APPVEYOR_REPO_NAME)" -a --baseDir "$Env:APPVEYOR_BUILD_FOLDER" --commit "$Env:APPVEYOR_REPO_COMMIT" $_.Fullname
+        & echo -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" -a --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }
     else{
-        gitlink -u "https://github.com/$($Env:APPVEYOR_REPO_NAME)" --baseDir "$Env:APPVEYOR_BUILD_FOLDER" --commit "$Env:APPVEYOR_REPO_COMMIT" $_.Fullname
+        & echo -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }    
 }

--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -1,6 +1,6 @@
 choco install gitlink --version 3.1.0-unstable0017 --pre --no-progress --limit-output
 
-Get-ChildItem -Recurse "*.pdb" | %{
+Get-ChildItem -Path ".\Output" -Recurse "*.pdb" | %{
     If ($_.Fullname -contains 'PitchTracker.pdb'){
         & gitlink -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" -a --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }

--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -1,0 +1,10 @@
+choco install gitlink --version 3.2.0-unstable0014 --pre
+
+Get-ChildItem -Recurse "*.pdb" | %{
+    If ($_.Fullname -contains 'PitchTracker.pdb'){
+        gitlink -u "https://github.com/$($Env:APPVEYOR_REPO_NAME)" -a --baseDir "$Env:APPVEYOR_BUILD_FOLDER" --commit "$Env:APPVEYOR_REPO_COMMIT" $_.Fullname
+    }
+    else{
+        gitlink -u "https://github.com/$($Env:APPVEYOR_REPO_NAME)" --baseDir "$Env:APPVEYOR_BUILD_FOLDER" --commit "$Env:APPVEYOR_REPO_COMMIT" $_.Fullname
+    }    
+}

--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -1,6 +1,6 @@
 choco install gitlink --version 3.1.0-unstable0017 --pre --no-progress --limit-output
 
-Get-ChildItem -Path ".\Output" -Recurse "*.pdb" | %{
+Get-ChildItem -Path ".\Output" -Recurse "*.pdb" | %{    
     If ($_.Fullname -contains 'PitchTracker.pdb'){
         & gitlink -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" -a --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }
@@ -8,3 +8,6 @@ Get-ChildItem -Path ".\Output" -Recurse "*.pdb" | %{
         & gitlink -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }    
 }
+
+# srcsrv were integrated in the pdb files -> delete the srcsrv files
+Remove-Item ".\Output\*.pdb.srcsrv"

--- a/.appveyor/runGitLink.ps1
+++ b/.appveyor/runGitLink.ps1
@@ -2,9 +2,9 @@ choco install gitlink --version 3.2.0-unstable0014 --pre --no-progress --limit-o
 
 Get-ChildItem -Recurse "*.pdb" | %{
     If ($_.Fullname -contains 'PitchTracker.pdb'){
-        & echo -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" -a --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
+        & gitlink -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" -a --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }
     else{
-        & echo -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
+        & gitlink -u "`"https://github.com/$($Env:APPVEYOR_REPO_NAME)`"" --baseDir "`"$Env:APPVEYOR_BUILD_FOLDER`"" --commit "`"$Env:APPVEYOR_REPO_COMMIT`"" "`"$($_.Fullname)`""
     }    
 }

--- a/PartyModes/PartyModeChallenge/PartyModeChallenge.csproj
+++ b/PartyModes/PartyModeChallenge/PartyModeChallenge.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -39,6 +39,7 @@
     <DefineConstants>WIN</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -54,7 +55,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -63,6 +64,7 @@
     <DefineConstants>LINUX</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'InstallerWin|AnyCPU'">
     <OutputPath>bin</OutputPath>
@@ -74,6 +76,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CChallengeRounds.cs" />

--- a/PartyModes/PartyModeTicTacToe/PartyModeTicTacToe.csproj
+++ b/PartyModes/PartyModeTicTacToe/PartyModeTicTacToe.csproj
@@ -30,7 +30,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -39,6 +39,7 @@
     <DefineConstants>WIN</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -54,7 +55,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -63,6 +64,7 @@
     <DefineConstants>LINUX</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'InstallerWin|AnyCPU'">
     <OutputPath>bin</OutputPath>
@@ -74,6 +76,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="CPartyScreenTicTacToeSongs.cs" />

--- a/PitchTracker/PitchTracker.vcxproj
+++ b/PitchTracker/PitchTracker.vcxproj
@@ -154,7 +154,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
@@ -177,7 +177,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <GenerateDebugInformation>false</GenerateDebugInformation>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>

--- a/PitchTracker/PitchTracker.vcxproj
+++ b/PitchTracker/PitchTracker.vcxproj
@@ -116,7 +116,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y</Command>
+      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y
+xcopy "$(OutDir)*.pdb" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -135,7 +136,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y</Command>
+      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y
+xcopy "$(OutDir)*.pdb" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -159,7 +161,8 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y</Command>
+      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y
+xcopy "$(OutDir)*.pdb" "$(SolutionDir)Output\libs\unmanaged\x64\" /I /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -182,7 +185,8 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y</Command>
+      <Command>xcopy "$(OutDir)*.dll" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y
+xcopy "$(OutDir)*.pdb" "$(SolutionDir)Output\libs\unmanaged\x86\" /I /Y</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Vocaluxe/Vocaluxe.csproj
+++ b/Vocaluxe/Vocaluxe.csproj
@@ -72,7 +72,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -81,6 +81,7 @@
     <DefineConstants>WIN;ARCH_X64</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'DebugLinux|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -120,7 +121,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseLinux|x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -129,6 +130,7 @@
     <DefineConstants>LINUX;ARCH_X64</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'InstallerWin|x86'">
     <PlatformTarget>x86</PlatformTarget>
@@ -144,7 +146,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'InstallerWin|x64'">
     <PlatformTarget>x64</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -153,6 +155,7 @@
     <DefineConstants>WIN;ARCH_X64;INSTALLER</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/VocaluxeLib/VocaluxeLib.csproj
+++ b/VocaluxeLib/VocaluxeLib.csproj
@@ -32,7 +32,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseWin|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\libs\managed</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -41,6 +41,7 @@
     <DefineConstants>WIN</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'DebugLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -56,7 +57,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'ReleaseLinux|AnyCPU'">
     <PlatformTarget>AnyCPU</PlatformTarget>
-    <DebugType>none</DebugType>
+    <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Output\libs\managed</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -65,6 +66,7 @@
     <DefineConstants>LINUX</DefineConstants>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'InstallerWin|AnyCPU'">
     <OutputPath>..\Output\libs\managed</OutputPath>
@@ -76,6 +78,8 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>ManagedMinimumRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>false</Prefer32Bit>
+    <DebugType>pdbonly</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,6 +50,8 @@ build:
   verbosity: normal
 after_build:
 - ps: |
+    ./.appveyor/runGitLink.ps1
+    
     cd Output
 
     $Env:MAIN_REPO = $False

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,9 +50,9 @@ build:
   verbosity: normal
 after_build:
 - ps: |
-    ./.appveyor/runGitLink.ps1
-    
     cd Output
+    
+    ./.appveyor/runGitLink.ps1
 
     $Env:MAIN_REPO = $False
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,9 +50,9 @@ build:
   verbosity: normal
 after_build:
 - ps: |
-    cd Output
-    
     ./.appveyor/runGitLink.ps1
+    
+    cd Output
 
     $Env:MAIN_REPO = $False
 


### PR DESCRIPTION
- Activation of pdb file generation
- Using [GitLink](https://github.com/GitTools/GitLink) to map the local source file path to the corresponding raw.github.com-file

You have to enable the `source server support` option in Visual Studio to be able to use the github files.

Can be used for debugging/profiling/crashdumps for release versions.