### PR TITLE
Changed version injection

### DIFF
--- a/.build/linuxPostBuildEvent.sh
+++ b/.build/linuxPostBuildEvent.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 PROJECT=$1
 cd $PROJECT
-sed -i -r -e 's/AssemblyInformationalVersion\(".*?"\)/AssemblyInformationalVersion("GITVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
-sed -i -r -e 's/AssemblyVersion\(".*?"\)/AssemblyVersion("SHORTVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
-sed -i -r -e 's/AssemblyFileVersion\(".*?"\)/AssemblyFileVersion("SHORTVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
-sed -i -r -e 's/AssemblyTitle\(".*?"\)/AssemblyTitle("FULLVERSION")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyInformationalVersion\(".*?"\)/AssemblyInformationalVersion("0.0.0-na-notversioned")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyVersion\(".*?"\)/AssemblyVersion("0.0.0")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyFileVersion\(".*?"\)/AssemblyFileVersion("0.0.0")/' $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e 's/AssemblyTitle\(".*?"\)/AssemblyTitle("Vocaluxe '"'"'Not Versioned'"'"' 0.0.0 (NA) (0.0.0-na-notversioned)")/' $PROJECT/Properties/AssemblyInfo.cs
 sed -i -e 's/var matchingServerVersion = "";/var matchingServerVersion = "'$(git describe --long)'";/' $PROJECT/../Output/Website/js/main.js

--- a/.build/linuxPreBuildEvent.sh
+++ b/.build/linuxPreBuildEvent.sh
@@ -24,6 +24,7 @@ esac
 versionName=$(grep -oP "\"${shortVersionClean%.*}.\" *: *\"\K([^\"]+)(?=\")" ../.build/versionNames.json)
 fullVersionName="Vocaluxe $([ "$versionName" == "" ] && echo "" || echo "'$versionName' ")$shortVersion ($arch) $([ "$releaseType" == "Release" ] && echo "" || echo "$releaseType ")($version)"
 
-sed -i -e s/GITVERSION/$(git describe --long)/ $PROJECT/Properties/AssemblyInfo.cs
-sed -i -e s/SHORTVERSION/"$shortVersionClean"/ $PROJECT/Properties/AssemblyInfo.cs
-sed -i -e s/FULLVERSION/"$fullVersionName"/ $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e "s/AssemblyInformationalVersion\(\".*?\"\)/AssemblyInformationalVersion(\"$(git describe --long)\")/" $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e "s/AssemblyVersion\(\".*?\"\)/AssemblyVersion(\"$shortVersionClean\")/" $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e "s/AssemblyFileVersion\(\".*?\"\)/AssemblyFileVersion(\"$shortVersionClean\")/" $PROJECT/Properties/AssemblyInfo.cs
+sed -i -r -e "s/AssemblyTitle\(\".*?\"\)/AssemblyTitle(\"$fullVersionName\")/" $PROJECT/Properties/AssemblyInfo.cs

--- a/.build/winPostBuild.ps1
+++ b/.build/winPostBuild.ps1
@@ -12,5 +12,5 @@ if($Env:VOCALUXE_SKIP_POSTBUILD)
 (Get-Content -Encoding UTF8 "$($ProjectDir)Properties\AssemblyInfo.cs") `
     | Foreach-Object {$_ -replace '(?<=AssemblyInformationalVersion\(\").*(?=\")', '0.0.0-na-notversioned'} `
     | Foreach-Object {$_ -replace '(?<=(AssemblyVersion|AssemblyFileVersion)\(\").*(?=\")', '0.0.0'} `
-    | Foreach-Object {$_ -replace '(?<=AssemblyTitle\(\").*(?=\")', 'Vocaluxe `'Not Versioned`' 0.0.0 (NA) (0.0.0-na-notversioned)'} `
+    | Foreach-Object {$_ -replace '(?<=AssemblyTitle\(\").*(?=\")', "Vocaluxe 'Not Versioned' 0.0.0 (NA) (0.0.0-na-notversioned)"} `
     | Set-Content -Encoding UTF8 "$($ProjectDir)Properties\AssemblyInfo.cs"

--- a/.build/winPostBuild.ps1
+++ b/.build/winPostBuild.ps1
@@ -17,7 +17,7 @@ else
     | Set-Content -Encoding UTF8 "$($ProjectDir)..\Output\Website\js\main.js"
 
 (Get-Content -Encoding UTF8 "$($ProjectDir)Properties\AssemblyInfo.cs") `
-    | Foreach-Object {$_ -replace '(?<=AssemblyInformationalVersion\(\").*(?=\")', 'GITVERSION'} `
-    | Foreach-Object {$_ -replace '(?<=(AssemblyVersion|AssemblyFileVersion)\(\").*(?=\")', 'SHORTVERSION'} `
-    | Foreach-Object {$_ -replace '(?<=AssemblyTitle\(\").*(?=\")', 'FULLVERSION'} `
+    | Foreach-Object {$_ -replace '(?<=AssemblyInformationalVersion\(\").*(?=\")', '0.0.0-na-notversioned'} `
+    | Foreach-Object {$_ -replace '(?<=(AssemblyVersion|AssemblyFileVersion)\(\").*(?=\")', '0.0.0'} `
+    | Foreach-Object {$_ -replace '(?<=AssemblyTitle\(\").*(?=\")', 'Vocaluxe `'Not Versioned`' 0.0.0 (NA) (0.0.0-na-notversioned)'} `
     | Set-Content -Encoding UTF8 "$($ProjectDir)Properties\AssemblyInfo.cs"

--- a/Vocaluxe/Properties/AssemblyInfo.cs
+++ b/Vocaluxe/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using System.Runtime.InteropServices;
 // Attribute gesteuert. Ändern Sie diese Attributwerte, um die Informationen zu ändern,
 // die mit einer Assembly verknüpft sind.
 
-[assembly: AssemblyTitle("FULLVERSION")]
+[assembly: AssemblyTitle("Vocaluxe 'Not Versioned' 0.0.0 (NA) (0.0.0-na-notversioned)")]
 [assembly: AssemblyDescription("")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
@@ -31,6 +31,10 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("Copyright © 2018")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
+
+[assembly: AssemblyVersion("0.0.0")]
+[assembly: AssemblyFileVersion("0.0.0")]
+[assembly: AssemblyInformationalVersion("0.0.0-na-notversioned")]
 
 // Durch Festlegen von ComVisible auf "false" werden die Typen in dieser Assembly unsichtbar 
 // für COM-Komponenten. Wenn Sie auf einen Typ in dieser Assembly von 
@@ -41,19 +45,6 @@ using System.Runtime.InteropServices;
 // Die folgende GUID bestimmt die ID der Typbibliothek, wenn dieses Projekt für COM verfügbar gemacht wird
 
 [assembly: Guid("da631594-f891-4994-9869-c37e626e44f9")]
-
-// Versionsinformationen für eine Assembly bestehen aus den folgenden vier Werten:
-//
-//      Hauptversion
-//      Nebenversion 
-//      Buildnummer
-//      Revision
-//
-
-[assembly: AssemblyVersion("SHORTVERSION")]
-[assembly: AssemblyFileVersion("SHORTVERSION")]
-[assembly: AssemblyInformationalVersion("GITVERSION")]
-
 
 // Allow internal access from the Tests project
 [assembly:InternalsVisibleTo("Tests")]


### PR DESCRIPTION
Do not longer use "SHORTVERSION", "GITVERSION", "FULLVERSION", because the do create warnings as they are not numeric or do not fulfill other constraints.
-> use dummy version numbers and tags.

+ Removed unused version tag injector for the old app