### PR TITLE
Extended search functions on song list screen (develop)

### DIFF
--- a/Vocaluxe/Base/CSongFilter.cs
+++ b/Vocaluxe/Base/CSongFilter.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -93,6 +93,89 @@ namespace Vocaluxe.Base
             if (_SearchString != "")
                 searchStrings = _SearchString.ToUpper().Split(new char[] {' '});
 
+            String searchForArtist = null;      // a:
+            String searchForTitle = null;       // t:
+            String searchForGenre = null;       // g:
+            String searchForYear = null;        // y:
+            String searchForLanguage = null;    // l:
+            String searchForCreator = null;     // c:
+            String searchForEdition = null;     // e:
+            String searchForAlbum = null;       // al:
+            String searchForFileName = null;    // fi:
+            String searchForFolderName = null;  // fo:
+            bool expertSearch = false;
+
+            if (searchStrings != null)
+            {
+                foreach (String searchToken in searchStrings)
+                {
+                    if (searchToken.Length < 3)
+                        continue;
+
+                    String temp = searchToken.Substring(0, 2);
+                    bool foundIt = true;
+
+                    switch (temp)
+                    {
+                        case "A:":
+                            searchForArtist = searchToken.Substring(2);
+                            break;
+                        case "T:":
+                            searchForTitle = searchToken.Substring(2);
+                            break;
+                        case "G:":
+                            searchForGenre = searchToken.Substring(2);
+                            break;
+                        case "Y:":
+                            searchForYear = searchToken.Substring(2);
+                            break;
+                        case "L:":
+                            searchForLanguage = searchToken.Substring(2);
+                            break;
+                        case "C:":
+                            searchForCreator = searchToken.Substring(2);
+                            break;
+                        case "E:":
+                            searchForEdition = searchToken.Substring(2);
+                            break;
+                        default:
+                            foundIt = false;
+                            break;
+                    }
+
+                    if (foundIt)
+                    {
+                        if (!expertSearch) expertSearch = true;
+                        continue;
+                    }
+
+                    if (searchToken.Length < 4)
+                        continue;
+
+                    foundIt = true;
+                    temp = searchToken.Substring(0, 3);
+
+                    switch (temp)
+                    {
+                        case "AL:":
+                            searchForAlbum = searchToken.Substring(3);
+                            break;
+                        case "FI:":
+                            searchForFileName = searchToken.Substring(3);
+                            break;
+                        case "FO:":
+                            searchForFolderName = searchToken.Substring(3);
+                            break;
+                        default:
+                            foundIt = false;
+                            break;
+                    }
+
+                    if (foundIt)
+                        if (!expertSearch) expertSearch = true;
+                }
+            }
+
             foreach (CSong song in CSongs.Songs)
             {
                 if (_PlaylistID != -1 && !CBase.Playlist.ContainsSong(_PlaylistID, song.ID))
@@ -102,9 +185,85 @@ namespace Vocaluxe.Base
                 {
                     if (searchStrings == null)
                         _FilteredSongs.Add(song);
+                    else if (expertSearch)
+                    {
+                        // Stefan1200: Stop at a maximum of 200 search result to prevent performance issues
+                        if (_FilteredSongs.Count >= 200)
+                            break;
+
+                        if (searchForAlbum != null && song.Album.ToUpper().Contains(searchForAlbum))
+                            _FilteredSongs.Add(song);
+                        if (searchForArtist != null && song.Artist.ToUpper().Contains(searchForArtist))
+                            _FilteredSongs.Add(song);
+                        if (searchForTitle != null && song.Title.ToUpper().Contains(searchForTitle))
+                            _FilteredSongs.Add(song);
+                        if (searchForCreator != null && song.Creator.ToUpper().Contains(searchForCreator))
+                            _FilteredSongs.Add(song);
+                        if (searchForFileName != null && song.FileName.ToUpper().Contains(searchForFileName))
+                            _FilteredSongs.Add(song);
+                        if (searchForFolderName != null && song.FolderName.ToUpper().Contains(searchForFolderName))
+                            _FilteredSongs.Add(song);
+
+                        if (searchForGenre != null)
+                        {
+                            foreach (String genre in song.Genres)
+                            {
+                                if (genre.ToUpper().Contains(searchForGenre))
+                                    _FilteredSongs.Add(song);
+                            }
+                        }
+
+                        if (searchForLanguage != null)
+                        {
+                            foreach (String language in song.Languages)
+                            {
+                                if (language.ToUpper().Contains(searchForLanguage))
+                                    _FilteredSongs.Add(song);
+                            }
+                        }
+
+                        if (searchForEdition != null)
+                        {
+                            foreach (String edition in song.Editions)
+                            {
+                                if (edition.ToUpper().Contains(searchForEdition))
+                                    _FilteredSongs.Add(song);
+                            }
+                        }
+
+                        if (searchForYear != null)
+                        {
+                            int pos = searchForYear.IndexOf("-");
+                            if (pos == -1)
+                            {
+                                if (song.Year.Contains(searchForYear))
+                                    _FilteredSongs.Add(song);
+                            }
+                            else if (searchForYear.Length == 9)
+                            {
+                                int yearStart = -1;
+                                int yearEnd = -1;
+                                if (!Int32.TryParse(searchForYear.Substring(0, pos), out yearStart))
+                                    continue;
+                                if (!Int32.TryParse(searchForYear.Substring(pos + 1), out yearEnd))
+                                    continue;
+
+                                // Stefan1200: Prevent searches like 0000-9999, limit for a max distance of 100 years
+                                if (yearEnd - yearStart > 100)
+                                    continue;
+
+                                int yearSearch = -1;
+                                if (!Int32.TryParse(song.Year, out yearSearch))
+                                    continue;
+
+                                if (yearSearch >= yearStart && yearSearch <= yearEnd)
+                                    _FilteredSongs.Add(song);
+                            }
+                        }
+                    }
                     else
                     {
-                        string search = song.Title.ToUpper() + " " + song.Artist.ToUpper() + " " + song.FolderName.ToUpper() + " " + song.FileName.ToUpper();
+                        string search = song.Title.ToUpper() + " " + song.Artist.ToUpper();
 
                         if (searchStrings.All(search.Contains))
                             _FilteredSongs.Add(song);


### PR DESCRIPTION
On the song list screen you can activate the search function by pressing F3 or CTRL+F, even in older Vocaluxe versions. In this commit I added special keywords for this search function to allow searching just for the artist or other items, like language or genre, which can't be searched in older Vocaluxe versions. (changed file CSongFilter.cs)

Use following keywords to search for a special item:
a: = artists
t: = title
g: = genre
y: = year, you can also do y:1980-1989 to find songs from the 80s
l: = language
c: = creator
e: = edition
al: = album
fi: = file name
fo: = folder name

**Examples:**
a:abba
y:1980-1989
y:1999
g:rock
l:german

**Additional notes:**
- If using this keywords, the maximum search results are limited to 200 songs.
- Changed the behavior if searching without keywords: Only title and artists will be searched, removed folder and file names.