### PR TITLE
Fix failing CLog tests

### DIFF
--- a/Tests/VocaluxeLib/Log/CLogTest.cs
+++ b/Tests/VocaluxeLib/Log/CLogTest.cs
@@ -76,7 +76,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Verbose] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -129,7 +129,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Verbose] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -287,7 +287,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Debug] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -340,7 +340,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Debug] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -498,7 +498,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Information] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -551,7 +551,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Information] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -709,7 +709,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Warning] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -762,7 +762,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Warning] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -920,7 +920,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Error] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 
@@ -973,7 +973,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[Error] " + _TestMessageWithResolvedData, log, "Main log entry wrong");
 
-                StringAssert.Contains(_TestMessageWithData, error, "Error message wrong");
+                StringAssert.Contains(_TestMessageWithResolvedData, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 

--- a/Tests/VocaluxeLib/Log/CLogTest.tt
+++ b/Tests/VocaluxeLib/Log/CLogTest.tt
@@ -101,7 +101,7 @@ namespace Tests.VocaluxeLib.Log
                 StringAssert.Contains("Version = " + versionTag, log, "Main log version tag entry wrong");
                 StringAssert.Contains("[<#= LogLevel #>] " + <#= WithData?"_TestMessageWithResolvedData":"_TestMessage" #>, log, "Main log entry wrong");
 
-                StringAssert.Contains(<#= WithData?"_TestMessageWithData":"_TestMessage" #>, error, "Error message wrong");
+                StringAssert.Contains(<#= WithData?"_TestMessageWithResolvedData":"_TestMessage" #>, error, "Error message wrong");
             },
             ELogLevel.Verbose);
 

--- a/VocaluxeLib/Log/CLog.cs
+++ b/VocaluxeLib/Log/CLog.cs
@@ -198,7 +198,7 @@ namespace VocaluxeLib.Log
             {
                 if (i >= propertyValues.Length)
                     return match.Value;
-                return propertyValues[i++].ToString();
+                return "\"" + propertyValues[i++] + "\"";
             });
         }
 


### PR DESCRIPTION
Changed the test cases + fixed `CLog._FormatMessageTemplate()` to align the layout