### PR TITLE
Add small text line with key shortcuts to Song Screen, allow some key shortcuts while search bar is active

### DIFF
--- a/Output/Languages/English.xml
+++ b/Output/Languages/English.xml
@@ -154,6 +154,7 @@
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
   <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start visible random • ESC = Back to main menu</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name</string>
+  <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Press your team number to use a random song joker</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Stop singing</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Continue</string>

--- a/Output/Languages/English.xml
+++ b/Output/Languages/English.xml
@@ -152,7 +152,7 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v songs)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v song)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start visible random • ESC = Back to main menu</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start listed random • ESC = Back to main menu</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name</string>
   <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Press your team number to use a random song joker</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>

--- a/Output/Languages/English.xml
+++ b/Output/Languages/English.xml
@@ -152,6 +152,8 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v songs)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v song)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter, F3 = Search, CTRL+R = Random selection, CTRL+S = Start medley, CTRL+A = Start all random, CTRL+V = Start visible random, ESC = Back to main menu</string>
+  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search: a: = artist / t: = title / c: = creator / e: = edition / g: = genre / y: = year (e.g. 1999 or 1980-1989) / l: = language / al: = album / fi: = file name / fo: = folder name</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Stop singing</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Continue</string>

--- a/Output/Languages/English.xml
+++ b/Output/Languages/English.xml
@@ -152,8 +152,8 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v songs)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v song)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter, F3 = Search, CTRL+R = Random selection, CTRL+S = Start medley, CTRL+A = Start all random, CTRL+V = Start visible random, ESC = Back to main menu</string>
-  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search: a: = artist / t: = title / c: = creator / e: = edition / g: = genre / y: = year (e.g. 1999 or 1980-1989) / l: = language / al: = album / fi: = file name / fo: = folder name</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start visible random • ESC = Back to main menu</string>
+  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Stop singing</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Continue</string>

--- a/Output/Languages/English.xml
+++ b/Output/Languages/English.xml
@@ -152,7 +152,7 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v songs)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v song)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start listed random • ESC = Back to main menu</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+A = Start all random • CTRL+V = Start visible random • Space = Open song options • ESC = Back to main menu</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name</string>
   <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Press your team number to use a random song joker</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>

--- a/Output/Languages/German.xml
+++ b/Output/Languages/German.xml
@@ -147,7 +147,7 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v Lieder)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v Lied)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a -%t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Sichtbare zufällig starten • ESC = Zurück zum Hauptmenü</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Aufgelistete zufällig starten • ESC = Zurück zum Hauptmenü</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche → a: = Interpret • t: = Titel • c: = Ersteller • e: = Edition • g: = Genre • y: = Jahr (z.B. 1999 oder 1980-1989) • l: = Sprache • al: = Album • fi: = Dateiname • fo: = Ordnername</string>
   <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Drücke die Teamnummer um einen Zufallssong Joker zu verwenden</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>

--- a/Output/Languages/German.xml
+++ b/Output/Languages/German.xml
@@ -147,6 +147,8 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v Lieder)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v Lied)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a -%t</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen, F3 = Suchen, STRG+R = Zufällige Auswahl, STRG+S = Starte Medley, STRG+A = Alle zufällig starten, STRG+V = Sichtbare zufällig starten, ESC = Zurück zum Hauptmenü</string>
+  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche: a: = Interpret / t: = Titel / c: = Ersteller / e: = Edition / g: = Genre / y: = Jahr (z.B. 1999 oder 1980-1989) / l: = Sprache / al: = Album / fi: = Dateiname / fo: = Ordnername</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Lied beenden</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Fortfahren</string>

--- a/Output/Languages/German.xml
+++ b/Output/Languages/German.xml
@@ -147,8 +147,8 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v Lieder)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v Lied)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a -%t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen, F3 = Suchen, STRG+R = Zufällige Auswahl, STRG+S = Starte Medley, STRG+A = Alle zufällig starten, STRG+V = Sichtbare zufällig starten, ESC = Zurück zum Hauptmenü</string>
-  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche: a: = Interpret / t: = Titel / c: = Ersteller / e: = Edition / g: = Genre / y: = Jahr (z.B. 1999 oder 1980-1989) / l: = Sprache / al: = Album / fi: = Dateiname / fo: = Ordnername</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Sichtbare zufällig starten • ESC = Zurück zum Hauptmenü</string>
+  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche → a: = Interpret • t: = Titel • c: = Ersteller • e: = Edition • g: = Genre • y: = Jahr (z.B. 1999 oder 1980-1989) • l: = Sprache • al: = Album • fi: = Dateiname • fo: = Ordnername</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Lied beenden</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Fortfahren</string>

--- a/Output/Languages/German.xml
+++ b/Output/Languages/German.xml
@@ -149,6 +149,7 @@
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a -%t</string>
   <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Sichtbare zufällig starten • ESC = Zurück zum Hauptmenü</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche → a: = Interpret • t: = Titel • c: = Ersteller • e: = Edition • g: = Genre • y: = Jahr (z.B. 1999 oder 1980-1989) • l: = Sprache • al: = Album • fi: = Dateiname • fo: = Ordnername</string>
+  <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Drücke die Teamnummer um einen Zufallssong Joker zu verwenden</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>
   <string name="TR_SCREENSING_BUTTON_CANCEL">Lied beenden</string>
   <string name="TR_SCREENSING_BUTTON_CONTINUE">Fortfahren</string>

--- a/Output/Languages/German.xml
+++ b/Output/Languages/German.xml
@@ -147,7 +147,7 @@
   <string name="TR_SCREENSONG_NUMSONGS">(%v Lieder)</string>
   <string name="TR_SCREENSONG_NUMSONG">(%v Lied)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a -%t</string>
-  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Aufgelistete zufällig starten • ESC = Zurück zum Hauptmenü</string>
+  <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Zum Buchstaben springen • F3 = Suchen • STRG+R = Zufällige Auswahl • STRG+S = Starte Medley • STRG+A = Alle zufällig starten • STRG+V = Sichtbare zufällig starten • Leertaste = Lied-Optionen öffnen • ESC = Zurück zum Hauptmenü</string>
   <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Interpreten und Titel durchsuchen, Präfixe für die Suche → a: = Interpret • t: = Titel • c: = Ersteller • e: = Edition • g: = Genre • y: = Jahr (z.B. 1999 oder 1980-1989) • l: = Sprache • al: = Album • fi: = Dateiname • fo: = Ordnername</string>
   <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Drücke die Teamnummer um einen Zufallssong Joker zu verwenden</string>
   <string name="TR_SCREENSING_PAUSE">Pause</string>

--- a/Output/Themes/Changelog/Changelog_ScreenSong.txt
+++ b/Output/Themes/Changelog/Changelog_ScreenSong.txt
@@ -1,6 +1,15 @@
 ScreenSong
 
 ++++++++++
+Version 7:
+
+Add:
+<TextHelpBar>
+<TextHelpBarSearch>
+<TextHelpBarParty>
+Shows key shortcut and search usage as small text line at the bottom of the screen.
+
+++++++++++
 Version 6:
 
 Add:

--- a/Output/Themes/Genius/Screens/ScreenSong.xml
+++ b/Output/Themes/Genius/Screens/ScreenSong.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenSong</ScreenName>
-    <ScreenVersion>6</ScreenVersion>
+    <ScreenVersion>7</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -237,6 +237,34 @@
       <Style>Bold</Style>
       <Font>Outline</Font>
       <Text>TR_SCREENSONG_SONGOPTIONS</Text>
+    </Text>
+    <Text Name="TextHelpBar">
+      <X>40</X>
+      <Y>700</Y>
+      <Z>0</Z>
+      <H>16</H>
+      <MaxW>1200</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Bottom</ResizeAlign>
+      <Style>Normal</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_HELPMESSAGE</Text>
+    </Text>
+    <Text Name="TextHelpBarSearch">
+      <X>40</X>
+      <Y>700</Y>
+      <Z>0</Z>
+      <H>16</H>
+      <MaxW>1200</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Bottom</ResizeAlign>
+      <Style>Normal</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_HELPMESSAGESEARCH</Text>
     </Text>
   </Texts>
   <Buttons>

--- a/Output/Themes/Genius/Screens/ScreenSong.xml
+++ b/Output/Themes/Genius/Screens/ScreenSong.xml
@@ -266,6 +266,20 @@
       <Font>Outline</Font>
       <Text>TR_SCREENSONG_HELPMESSAGESEARCH</Text>
     </Text>
+    <Text Name="TextHelpBarParty">
+      <X>40</X>
+      <Y>700</Y>
+      <Z>0</Z>
+      <H>16</H>
+      <MaxW>1200</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Bottom</ResizeAlign>
+      <Style>Normal</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_HELPMESSAGEPARTY</Text>
+    </Text>
   </Texts>
   <Buttons>
     <Button Name="ButtonJoker1">

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -42,7 +42,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 6; }
+            get { return 7; }
         }
 
         private const string _TextCategory = "TextCategory";

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1056,7 +1056,7 @@ namespace Vocaluxe.Screens
         private void _JumpTo(char letter)
         {
             int start = 0;
-            //int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
+            int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
             bool secondSort = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_ON &&
                               (CConfig.Config.Game.SongSorting == ESongSorting.TR_CONFIG_ARTIST ||
@@ -1068,7 +1068,7 @@ namespace Vocaluxe.Screens
                 //TODO: What's to do with multiple tags?
                 //Flamefire: What? We only sorted by one tag, sorting by multiple tags (e.g. Album) will be by e.g. the first entry. That can be used here too as otherwhise it will confuse users because it jumps randomly
                 ReadOnlyCollection<CSong> songs = CSongs.VisibleSongs;
-                //int ct = songs.Count;
+                int ct = songs.Count;
                 int visibleID = -1;
                 switch (CConfig.Config.Game.SongSorting)
                 {
@@ -1104,7 +1104,7 @@ namespace Vocaluxe.Screens
             else if (secondSort && CSongs.IsInCategory)
             {
                 ReadOnlyCollection<CSong> songs = CSongs.VisibleSongs;
-                //int ct = songs.Count;
+                int ct = songs.Count;
                 int visibleID = -1;
                 switch (CConfig.Config.Game.SongSorting)
                 {
@@ -1128,7 +1128,7 @@ namespace Vocaluxe.Screens
             else if (!CSongs.IsInCategory)
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
-                //int ct = categories.Count;
+                int ct = categories.Count;
                 if (curSelected >= 0 && curSelected < ct - 1 && categories[curSelected].Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
                     start = curSelected + 1;
                 int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -80,9 +80,6 @@ namespace Vocaluxe.Screens
         private string _SearchText = String.Empty;
         private bool _SearchActive;
 
-        private int _JumpTo_lastCharTime = 0;
-        private String _JumpTo_lastSearchString = "";
-
         private readonly List<string> _ButtonsJoker = new List<string>();
         private readonly List<string> _TextsPlayer = new List<string>();
         private ESongOptionsView _CurSongOptionsView;
@@ -288,6 +285,21 @@ namespace Vocaluxe.Screens
                             else if (!_Sso.Selection.PartyMode)
                                 _SearchActive = true;
                             break;
+
+                        case Keys.V:
+                            if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.PartyMode)
+                                _StartRandomVisibleSongs();
+                            break;
+
+                        case Keys.R:
+                            if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.RandomOnly)
+                                _SelectNextRandom(-1);
+                            break;
+
+                        case Keys.S:
+                            if (keyEvent.Mod == EModifier.Ctrl && CSongs.NumSongsVisible > 0 && !_Sso.Selection.PartyMode)
+                                _StartMedleySong(_SongMenu.GetPreviewSongNr());
+                            break;
                     }
                     if (!_SearchActive)
                     {
@@ -301,20 +313,6 @@ namespace Vocaluxe.Screens
                             case Keys.A:
                                 if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.PartyMode)
                                     _StartRandomAllSongs();
-                                break;
-                            case Keys.V:
-                                if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.PartyMode)
-                                    _StartRandomVisibleSongs();
-                                break;
-
-                            case Keys.R:
-                                if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.RandomOnly)
-                                    _SelectNextRandom(-1);
-                                break;
-
-                            case Keys.S:
-                                if (keyEvent.Mod == EModifier.Ctrl && CSongs.NumSongsVisible > 0 && !_Sso.Selection.PartyMode)
-                                    _StartMedleySong(_SongMenu.GetPreviewSongNr());
                                 break;
 
                             case Keys.F:
@@ -1057,13 +1055,6 @@ namespace Vocaluxe.Screens
 
         private void _JumpTo(char letter)
         {
-            // Stefan1200: Add all letters from a key press within one second to a search string. Clear search string, if last key press is older than one second.
-            String searchString;
-            if (Environment.TickCount - _JumpTo_lastCharTime < 1000)
-                searchString = _JumpTo_lastSearchString + letter.ToString();
-            else
-                searchString = letter.ToString();
-
             int start = 0;
             //int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
@@ -1083,20 +1074,28 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_YEAR:
                     case ESongSorting.TR_CONFIG_DECADE:
-                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_FOLDER:
-                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1111,12 +1110,16 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_FOLDER:
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1126,14 +1129,12 @@ namespace Vocaluxe.Screens
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
                 //int ct = categories.Count;
-                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                if (curSelected >= 0 && curSelected < ct - 1 && categories[curSelected].Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                    start = curSelected + 1;
+                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                 if (visibleID > -1)
                     _SongMenu.SetSelectedCategory(visibleID);
             }
-
-            // Stefan1200: Remember search string and current TickCount in class variables.
-            _JumpTo_lastCharTime = Environment.TickCount;
-            _JumpTo_lastSearchString = searchString;
         }
 
         private void _ApplyNewSearchFilter(string newFilterString)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1065,7 +1065,7 @@ namespace Vocaluxe.Screens
                 searchString = letter.ToString();
 
             int start = 0;
-            int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
+            //int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
             bool secondSort = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_ON &&
                               (CConfig.Config.Game.SongSorting == ESongSorting.TR_CONFIG_ARTIST ||
@@ -1077,7 +1077,7 @@ namespace Vocaluxe.Screens
                 //TODO: What's to do with multiple tags?
                 //Flamefire: What? We only sorted by one tag, sorting by multiple tags (e.g. Album) will be by e.g. the first entry. That can be used here too as otherwhise it will confuse users because it jumps randomly
                 ReadOnlyCollection<CSong> songs = CSongs.VisibleSongs;
-                int ct = songs.Count;
+                //int ct = songs.Count;
                 int visibleID = -1;
                 switch (CConfig.Config.Game.SongSorting)
                 {
@@ -1105,7 +1105,7 @@ namespace Vocaluxe.Screens
             else if (secondSort && CSongs.IsInCategory)
             {
                 ReadOnlyCollection<CSong> songs = CSongs.VisibleSongs;
-                int ct = songs.Count;
+                //int ct = songs.Count;
                 int visibleID = -1;
                 switch (CConfig.Config.Game.SongSorting)
                 {
@@ -1125,7 +1125,7 @@ namespace Vocaluxe.Screens
             else if (!CSongs.IsInCategory)
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
-                int ct = categories.Count;
+                //int ct = categories.Count;
                 int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                 if (visibleID > -1)
                     _SongMenu.SetSelectedCategory(visibleID);

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -42,13 +42,15 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 6; }
+            get { return 7; }
         }
 
         private const string _TextCategory = "TextCategory";
         private const string _TextSelection = "TextSelection";
         private const string _TextSearchBarTitle = "TextSearchBarTitle";
         private const string _TextSearchBar = "TextSearchBar";
+        private const string _TextHelpBar = "TextHelpBar";
+        private const string _TextHelpBarSearch = "TextHelpBarSearch";
         private const string _TextOptionsTitle = "TextOptionsTitle";
 
         private const string _ButtonOpenOptions = "ButtonOpenOptions";
@@ -76,6 +78,9 @@ namespace Vocaluxe.Screens
 
         private string _SearchText = String.Empty;
         private bool _SearchActive;
+
+        private int _JumpTo_lastCharTime = 0;
+        private String _JumpTo_lastSearchString = "";
 
         private readonly List<string> _ButtonsJoker = new List<string>();
         private readonly List<string> _TextsPlayer = new List<string>();
@@ -134,6 +139,8 @@ namespace Vocaluxe.Screens
             tlist.Add(_TextSelection);
             tlist.Add(_TextSearchBarTitle);
             tlist.Add(_TextSearchBar);
+            tlist.Add(_TextHelpBar);
+            tlist.Add(_TextHelpBarSearch);
             tlist.Add(_TextOptionsTitle);
 
             _ThemeStatics = new string[] {_StaticSearchBar, _StaticOptionsBG};
@@ -727,12 +734,16 @@ namespace Vocaluxe.Screens
 
                 _Texts[_TextSearchBar].Visible = true;
                 _Texts[_TextSearchBarTitle].Visible = true;
+                _Texts[_TextHelpBar].Visible = false;
+                _Texts[_TextHelpBarSearch].Visible = true;
                 _Statics[_StaticSearchBar].Visible = true;
             }
             else
             {
                 _Texts[_TextSearchBar].Visible = false;
                 _Texts[_TextSearchBarTitle].Visible = false;
+                _Texts[_TextHelpBar].Visible = true;
+                _Texts[_TextHelpBarSearch].Visible = false;
                 _Statics[_StaticSearchBar].Visible = false;
             }
 
@@ -1042,6 +1053,13 @@ namespace Vocaluxe.Screens
 
         private void _JumpTo(char letter)
         {
+            // Stefan1200: Add all letters from a key press within one second to a search string. Clear search string, if last key press is older than one second.
+            String searchString;
+            if (Environment.TickCount - _JumpTo_lastCharTime < 1000)
+                searchString = _JumpTo_lastSearchString + letter.ToString();
+            else
+                searchString = letter.ToString();
+
             int start = 0;
             int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
@@ -1061,28 +1079,20 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_YEAR:
                     case ESongSorting.TR_CONFIG_DECADE:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_FOLDER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1097,16 +1107,12 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_FOLDER:
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1116,12 +1122,14 @@ namespace Vocaluxe.Screens
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
                 int ct = categories.Count;
-                if (curSelected >= 0 && curSelected < ct - 1 && categories[curSelected].Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                    start = curSelected + 1;
-                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                 if (visibleID > -1)
                     _SongMenu.SetSelectedCategory(visibleID);
             }
+
+            // Stefan1200: Remember search string and current TickCount in class variables.
+            _JumpTo_lastCharTime = Environment.TickCount;
+            _JumpTo_lastSearchString = searchString;
         }
 
         private void _ApplyNewSearchFilter(string newFilterString)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -51,6 +51,7 @@ namespace Vocaluxe.Screens
         private const string _TextSearchBar = "TextSearchBar";
         private const string _TextHelpBar = "TextHelpBar";
         private const string _TextHelpBarSearch = "TextHelpBarSearch";
+        private const string _TextHelpBarParty = "TextHelpBarParty";
         private const string _TextOptionsTitle = "TextOptionsTitle";
 
         private const string _ButtonOpenOptions = "ButtonOpenOptions";
@@ -78,6 +79,9 @@ namespace Vocaluxe.Screens
 
         private string _SearchText = String.Empty;
         private bool _SearchActive;
+
+        private int _JumpTo_lastCharTime = 0;
+        private String _JumpTo_lastSearchString = "";
 
         private readonly List<string> _ButtonsJoker = new List<string>();
         private readonly List<string> _TextsPlayer = new List<string>();
@@ -138,6 +142,7 @@ namespace Vocaluxe.Screens
             tlist.Add(_TextSearchBar);
             tlist.Add(_TextHelpBar);
             tlist.Add(_TextHelpBarSearch);
+            tlist.Add(_TextHelpBarParty);
             tlist.Add(_TextOptionsTitle);
 
             _ThemeStatics = new string[] {_StaticSearchBar, _StaticOptionsBG};
@@ -313,7 +318,7 @@ namespace Vocaluxe.Screens
                                 break;
 
                             case Keys.F:
-                                if (keyEvent.Mod == EModifier.Ctrl)
+                                if (keyEvent.Mod == EModifier.Ctrl && !_Sso.Selection.PartyMode)
                                     _SearchActive = true;
                                 break;
 
@@ -733,14 +738,16 @@ namespace Vocaluxe.Screens
                 _Texts[_TextSearchBarTitle].Visible = true;
                 _Texts[_TextHelpBar].Visible = false;
                 _Texts[_TextHelpBarSearch].Visible = true;
+                _Texts[_TextHelpBarParty].Visible = false;
                 _Statics[_StaticSearchBar].Visible = true;
             }
             else
             {
                 _Texts[_TextSearchBar].Visible = false;
                 _Texts[_TextSearchBarTitle].Visible = false;
-                _Texts[_TextHelpBar].Visible = true;
+                _Texts[_TextHelpBar].Visible = !_Sso.Selection.PartyMode;
                 _Texts[_TextHelpBarSearch].Visible = false;
+                _Texts[_TextHelpBarParty].Visible = _Sso.Selection.PartyMode;
                 _Statics[_StaticSearchBar].Visible = false;
             }
 
@@ -1050,6 +1057,13 @@ namespace Vocaluxe.Screens
 
         private void _JumpTo(char letter)
         {
+            // Stefan1200: Add all letters from a key press within one second to a search string. Clear search string, if last key press is older than one second.
+            String searchString;
+            if (Environment.TickCount - _JumpTo_lastCharTime < 1000)
+                searchString = _JumpTo_lastSearchString + letter.ToString();
+            else
+                searchString = letter.ToString();
+
             int start = 0;
             int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
@@ -1069,28 +1083,20 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_YEAR:
                     case ESongSorting.TR_CONFIG_DECADE:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_FOLDER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1105,16 +1111,12 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_FOLDER:
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                            start = curSelected + 1;
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1124,12 +1126,14 @@ namespace Vocaluxe.Screens
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
                 int ct = categories.Count;
-                if (curSelected >= 0 && curSelected < ct - 1 && categories[curSelected].Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
-                    start = curSelected + 1;
-                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
+                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
                 if (visibleID > -1)
                     _SongMenu.SetSelectedCategory(visibleID);
             }
+
+            // Stefan1200: Remember search string and current TickCount in class variables.
+            _JumpTo_lastCharTime = Environment.TickCount;
+            _JumpTo_lastSearchString = searchString;
         }
 
         private void _ApplyNewSearchFilter(string newFilterString)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -42,7 +42,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 7; }
+            get { return 6; }
         }
 
         private const string _TextCategory = "TextCategory";
@@ -78,9 +78,6 @@ namespace Vocaluxe.Screens
 
         private string _SearchText = String.Empty;
         private bool _SearchActive;
-
-        private int _JumpTo_lastCharTime = 0;
-        private String _JumpTo_lastSearchString = "";
 
         private readonly List<string> _ButtonsJoker = new List<string>();
         private readonly List<string> _TextsPlayer = new List<string>();
@@ -1053,13 +1050,6 @@ namespace Vocaluxe.Screens
 
         private void _JumpTo(char letter)
         {
-            // Stefan1200: Add all letters from a key press within one second to a search string. Clear search string, if last key press is older than one second.
-            String searchString;
-            if (Environment.TickCount - _JumpTo_lastCharTime < 1000)
-                searchString = _JumpTo_lastSearchString + letter.ToString();
-            else
-                searchString = letter.ToString();
-
             int start = 0;
             int curSelected = CSongs.IsInCategory ? _SongMenu.GetSelectedSongNr() : _SongMenu.GetSelectedCategory();
             bool firstLevel = CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_OFF && CSongs.IsInCategory;
@@ -1079,20 +1069,28 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_YEAR:
                     case ESongSorting.TR_CONFIG_DECADE:
-                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Year.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_FOLDER:
-                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Folder.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1107,12 +1105,16 @@ namespace Vocaluxe.Screens
                 {
                     case ESongSorting.TR_CONFIG_FOLDER:
                     case ESongSorting.TR_CONFIG_TITLE_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Artist.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
 
                     case ESongSorting.TR_CONFIG_ARTIST:
                     case ESongSorting.TR_CONFIG_ARTIST_LETTER:
-                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                        if (curSelected >= 0 && curSelected < ct - 1 && songs[curSelected].Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                            start = curSelected + 1;
+                        visibleID = _FindIndex(songs, start, element => element.Title.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                         break;
                 }
                 if (visibleID > -1)
@@ -1122,14 +1124,12 @@ namespace Vocaluxe.Screens
             {
                 ReadOnlyCollection<CCategory> categories = CSongs.Categories;
                 int ct = categories.Count;
-                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(searchString, StringComparison.OrdinalIgnoreCase));
+                if (curSelected >= 0 && curSelected < ct - 1 && categories[curSelected].Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase))
+                    start = curSelected + 1;
+                int visibleID = _FindIndex(categories, start, element => element.Name.StartsWith(letter.ToString(), StringComparison.OrdinalIgnoreCase));
                 if (visibleID > -1)
                     _SongMenu.SetSelectedCategory(visibleID);
             }
-
-            // Stefan1200: Remember search string and current TickCount in class variables.
-            _JumpTo_lastCharTime = Environment.TickCount;
-            _JumpTo_lastSearchString = searchString;
         }
 
         private void _ApplyNewSearchFilter(string newFilterString)


### PR DESCRIPTION
Add a small text line with key shortcuts to Song Screen, toggled if the search bar is active with help to the extended search keywords added by another commit. English and German text included in this commit.

Search bar invisible:
![image](https://user-images.githubusercontent.com/15168351/72219494-0caf8100-3547-11ea-9c2a-530ee5939d5d.png)

Search bar visible:
![image](https://user-images.githubusercontent.com/15168351/72200106-6def2b80-3445-11ea-9698-c897111dfa1c.png)

Party mode active:
![image](https://user-images.githubusercontent.com/15168351/72200653-59626180-344c-11ea-83bb-6dcd64454781.png)

**Small update related to this:**
On Song Screen the key shortcuts CTRL + R, CTRL + V and CTRL + S are now also allowed, if the Search Bar is visible. Especially CTRL + V is nice for this, because it allows you to sing all songs from the search result in random order. Example: You want to sing just songs with the genre rock? Do a search for g:rock and press CTRL + V. Have fun.

Small bug fix: CTRL + F is now disabled on song screen at party mode. It never really worked, but it was displayed for a short time.