### PR TITLE
Fix: github deployments use the old and invalid token

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -135,7 +135,7 @@ deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   description: $(APPVEYOR_REPO_COMMIT)
   auth_token:
-    secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
+    secure: sGetWh2XUYs95VBT+QYNPtDW9Rh2/JBuxNNYXytpn7mMudUMcjSKDGErkCTum+ZE
   artifact: ReleaseZip
   prerelease: $(IS_BETA_RELEASE)
   on:
@@ -147,7 +147,7 @@ deploy:
   release: Latest Nightly build
   description: $(APPVEYOR_REPO_COMMIT)
   auth_token:
-    secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
+    secure: sGetWh2XUYs95VBT+QYNPtDW9Rh2/JBuxNNYXytpn7mMudUMcjSKDGErkCTum+ZE
   artifact: ReleaseZip
   prerelease: true
   on:


### PR DESCRIPTION
forgot to update zwo other occurrences of the old and invalid key 🙄 