### PR TITLE
Automatic switch of aspect ratio for background video & image on sing screen

### DIFF
--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -112,7 +112,7 @@ namespace Vocaluxe.Screens
         private float _Length = -1f;
 
         private CVideoStream _CurrentVideo;
-        private EAspect _VideoAspect = EAspect.Crop;
+        private EAspect _VideoAspect = EAspect.Automatic;
         private CTextureRef _CurrentWebcamFrameTexture;
         private CTextureRef _Background;
 
@@ -794,18 +794,21 @@ namespace Vocaluxe.Screens
                 if (_CurrentVideo != null && CConfig.Config.Video.VideosInSongs == EOffOn.TR_CONFIG_ON && !_Webcam)
                 {
                     background = _CurrentVideo.Texture;
-                    aspect = _VideoAspect;
                 }
                 else if (_Webcam)
                 {
                     background = _CurrentWebcamFrameTexture;
-                    aspect = _VideoAspect;
                 }
                 else
                     background = _Background;
                 if (background != null)
                 {
                     SRectF bounds = CSettings.RenderRect;
+					
+					if (_VideoAspect == EAspect.Automatic)
+                        _VideoAspect = (background.OrigAspect <= 1.5 ? EAspect.LetterBox : EAspect.Crop);
+                    aspect = _VideoAspect;
+					
                     SRectF rect = CHelper.FitInBounds(bounds, background.OrigAspect, aspect);
                     CDraw.DrawTexture(background, rect, background.Color, bounds);
                 }
@@ -1087,7 +1090,7 @@ namespace Vocaluxe.Screens
             {
                 _CurrentVideo = CVideo.Load(Path.Combine(song.Folder, song.VideoFileName));
                 CVideo.Skip(_CurrentVideo, song.Start, song.VideoGap);
-                _VideoAspect = song.VideoAspect;
+                _VideoAspect = EAspect.Automatic;
             }
 
             CDraw.RemoveTexture(ref _Background);

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -804,11 +804,11 @@ namespace Vocaluxe.Screens
                 if (background != null)
                 {
                     SRectF bounds = CSettings.RenderRect;
-					
-					if (_VideoAspect == EAspect.Automatic)
+                    
+                    if (_VideoAspect == EAspect.Automatic)
                         _VideoAspect = (background.OrigAspect <= 1.5 ? EAspect.LetterBox : EAspect.Crop);
                     aspect = _VideoAspect;
-					
+                    
                     SRectF rect = CHelper.FitInBounds(bounds, background.OrigAspect, aspect);
                     CDraw.DrawTexture(background, rect, background.Color, bounds);
                 }

--- a/VocaluxeLib/CHelper.cs
+++ b/VocaluxeLib/CHelper.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -101,6 +101,7 @@ namespace VocaluxeLib
 
             switch (aspect)
             {
+                case EAspect.Automatic:
                 case EAspect.Crop:
                     if (boundsAspectRatio >= aspectRatio)
                     {
@@ -138,7 +139,12 @@ namespace VocaluxeLib
                     }
                     break;
                 case EAspect.LetterBox:
-                    if (boundsAspectRatio <= aspectRatio)
+                    if (boundsAspectRatio == aspectRatio)  // Pillarbox
+                    {
+                        scaledWidth = bounds.W * 0.77f;
+                        scaledHeight = bounds.W / aspectRatio;
+                    }
+                    else if (boundsAspectRatio < aspectRatio)
                     {
                         scaledWidth = bounds.W;
                         scaledHeight = bounds.W / aspectRatio;

--- a/VocaluxeLib/Enums.cs
+++ b/VocaluxeLib/Enums.cs
@@ -64,6 +64,7 @@ namespace VocaluxeLib
     #region Fonts
     public enum EAspect
     {
+        Automatic,
         Crop,
         LetterBox,
         Stretch,

--- a/VocaluxeLib/Songs/CSong.cs
+++ b/VocaluxeLib/Songs/CSong.cs
@@ -101,7 +101,7 @@ namespace VocaluxeLib.Songs
         public readonly List<string> BackgroundFileNames = new List<string>();
         public string VideoFileName = String.Empty;
 
-        public EAspect VideoAspect = EAspect.Crop;
+        public EAspect VideoAspect = EAspect.Automatic;
 
         public bool NotesLoaded { get; private set; }
 


### PR DESCRIPTION
If the aspect ratio (width / height) of the background video or image is below or equal to 1.5, switch to EAspect.LetterBox (it's like pressing the v key while singing one time by default). If not, leave it at EAspect.Crop (like in Vocaluxe before). This detects 4:3 videos and adds black borders to the left and right, instead of cropping parts of the video (on the top and bottom).

Unfortunately the acinerella library, used by Vocaluxe, don't support reading of the DAR value of the video file. So the SAR value (the real resolution of the video file) has to be correct in the video file, to see this automatic in action.

Second change: If the background video and Vocaluxe have the same aspect ratio, switching the aspect ratio to LetterBox (one press of the v key) would do a Pillarbox. That allows to add borders to the left and right (like 4:3), if a video file has the wrong aspect ratio (maybe SAR value at 16:9, but a DAR value at 4:3). Without this change, LetterBox would do exactly the same as Crop in this special case.

**Your opinions? Are there votes against this?** It could be possible to add an on/off toggle to the video options, if someone don't like this.

Fixes #395 