### PR TITLE
Workaround to allow cover theme changes without restarting game

### DIFF
--- a/Vocaluxe/Base/CCover.cs
+++ b/Vocaluxe/Base/CCover.cs
@@ -133,6 +133,11 @@ namespace Vocaluxe.Base
         {
             _UnloadCovers();
             _LoadCovers();
+
+            // Stefan1200: Added a workaround to fix issue #446, because switching the cover theme gets bugged on the song screen and needed a game restart.
+            //             Toggle the tabs view fixes this bug somehow.
+            CSongs.Categorizer.Tabs = (CConfig.Config.Game.Tabs == EOffOn.TR_CONFIG_ON ? EOffOn.TR_CONFIG_OFF : EOffOn.TR_CONFIG_ON);
+            CSongs.Categorizer.Tabs = CConfig.Config.Game.Tabs;
         }
 
         private static void _UnloadCovers()


### PR DESCRIPTION
Just a workaround for issue #446 

Known side effects: After some cover theme changes the garbage collector can slow down drawing the song screen for some seconds. But this work around was implemented at a code position, which will only affects cover theme changes. So this workaround is still better than without it.