### PR TITLE
Fix: Wrong lyric colors in duet mode (fix #361)

### DIFF
--- a/Output/Themes/Genius/Screens/ScreenSing.xml
+++ b/Output/Themes/Genius/Screens/ScreenSing.xml
@@ -46,7 +46,7 @@
       <Color Name="BackgroundColorAlpha" />
       <Rect>
         <X>0</X>
-        <Y>0</Y>
+        <Y>610</Y>
         <W>1280</W>
         <H>90</H>
         <Z>-0.75</Z>
@@ -136,7 +136,7 @@
       <Color Name="LyricHelperDuet" />
       <Rect>
         <X>40</X>
-        <Y>10</Y>
+        <Y>623</Y>
         <W>45</W>
         <H>36</H>
         <Z>-1</Z>
@@ -1501,7 +1501,7 @@
     <Lyric Name="LyricMainDuet">
       <Rect>
         <X>637</X>
-        <Y>7</Y>
+        <Y>620</Y>
         <W>1200</W>
         <H>42</H>
         <Z>-1</Z>
@@ -1512,7 +1512,7 @@
     <Lyric Name="LyricSubDuet">
       <Rect>
         <X>637</X>
-        <Y>48</Y>
+        <Y>662</Y>
         <W>1200</W>
         <H>35</H>
         <Z>-1</Z>

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -532,7 +532,7 @@ namespace Vocaluxe.Screens
                             _SingNotes[_SingBars].PlayerNotes[j].SetLine(nr);
                     }
 
-                    if (i == 0 && !song.IsDuet || i == 1 && song.IsDuet)
+                    if (i == 0)
                     {
                         _Lyrics[_LyricMain].SetLine(lines[nr]);
                         _Lyrics[_LyricMainTop].SetLine(lines[nr]);
@@ -550,7 +550,7 @@ namespace Vocaluxe.Screens
                             _Lyrics[_LyricSubTop].Clear();
                         }
                     }
-                    if (i == 0 && song.IsDuet)
+                    if (i == 1 && song.IsDuet)
                     {
                         _Lyrics[_LyricMainDuet].SetLine(lines[nr]);
                         _TimeToFirstNoteDuet = CGame.GetTimeFromBeats(lines[nr].FirstNoteBeat - lines[nr].StartBeat, song.BPM);
@@ -564,7 +564,7 @@ namespace Vocaluxe.Screens
                 }
                 else
                 {
-                    if (i == 0 && !song.IsDuet || i == 1 && song.IsDuet)
+                    if (i == 0)
                     {
                         _Lyrics[_LyricMain].Clear();
                         _Lyrics[_LyricSub].Clear();
@@ -573,7 +573,7 @@ namespace Vocaluxe.Screens
                         _TimeToFirstNote = 0f;
                     }
 
-                    if (i == 0 && song.IsDuet)
+                    if (i == 1 && song.IsDuet)
                     {
                         _Lyrics[_LyricMainDuet].Clear();
                         _Lyrics[_LyricSubDuet].Clear();
@@ -1199,8 +1199,8 @@ namespace Vocaluxe.Screens
 
             if (CGame.GetSong() != null && CGame.GetSong().IsDuet)
             {
-                bottomLyricsVisible = true;
-                topLyricsVisible = false;
+                bottomLyricsVisible = false;
+                topLyricsVisible = true;
                 duetLyricsVisible = true;
             }
 

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -879,7 +879,7 @@ namespace Vocaluxe.Screens
                         _Statics[_StaticLyricHelperTop].Color.R,
                         _Statics[_StaticLyricHelperTop].Color.G,
                         _Statics[_StaticLyricHelperTop].Color.B,
-                        _Statics[_StaticLyricHelperTop].Color.A * _Statics[_StaticLyricHelper].Alpha * alpha);
+                        _Statics[_StaticLyricHelperTop].Color.A * _Statics[_StaticLyricHelperTop].Alpha * alpha);
 
                     float distance = _Lyrics[_LyricMainTop].GetCurrentLyricPosX() - rect.X - rect.W;
                     CDraw.DrawTexture(_Statics[_StaticLyricHelperTop].Texture,


### PR DESCRIPTION
Looks good on my end, tested:
**Duet**
**Normal** with lyrics set to **bottom** and **top** position

![image](https://user-images.githubusercontent.com/15168351/72646271-09b4f600-3976-11ea-99cd-d4e01ac2158f.png)

And another very very small bug was fixed:
If the lyrics position is on top, the wrong alpha value was used from Genius theme. In the Vocaluxe default Genius theme both values are the same, that's why no one did know about this bug.