### PR TITLE
Keyboard shortcut and button to show the highscores of the selected song

### DIFF
--- a/Output/Themes/Genius/Screens/ScreenSong.xml
+++ b/Output/Themes/Genius/Screens/ScreenSong.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenSong</ScreenName>
-    <ScreenVersion>7</ScreenVersion>
+    <ScreenVersion>8</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -786,6 +786,33 @@
         <Style>Bold</Style>
         <Font>Outline</Font>
         <Text>TR_SCREENSONG_BUTTON_STARTMEDLEY</Text>
+      </Text>
+    </Button>
+    <Button Name="ButtonOptionsHighscore">
+      <Skin>SongSelectButton</Skin>
+      <SkinSelected>SongSelectButton</SkinSelected>
+      <Rect>
+        <X>40</X>
+        <Y>290</Y>
+        <W>360</W>
+        <H>40</H>
+        <Z>-2.11</Z>
+      </Rect>
+      <Color Name="ButtonColor" />
+      <SelColor Name="ButtonSelColor" />
+      <Text Name="Text">
+        <X>180</X>
+        <Y>7</Y>
+        <Z>0</Z>
+        <H>25</H>
+        <MaxW>350</MaxW>
+        <Color Name="ButtonTextColor" />
+        <SelColor Name="ButtonTextSelColor" />
+        <Align>Center</Align>
+        <ResizeAlign>Center</ResizeAlign>
+        <Style>Bold</Style>
+        <Font>Outline</Font>
+        <Text>TR_SCREENHIGHSCORE_HIGHSCORE</Text>
       </Text>
     </Button>
   </Buttons>

--- a/Vocaluxe/Base/CBackgroundMusic.cs
+++ b/Vocaluxe/Base/CBackgroundMusic.cs
@@ -316,56 +316,33 @@ namespace Vocaluxe.Base
                 CSound.SetGlobalVolume(CConfig.PreviewMusicVolume);
             }
 
+            //Change song position only if song is changed or near to end
             bool songChanged = _CurPlayer.SongID != song.ID;
+            if (!songChanged && _CurPlayer.Position + 30 < _CurPlayer.Length)
+                return;
 
             _PreviewPlayer.Load(song);
-            
 
-            //Change song position only if song is changed or near to end
-            if (songChanged || _CurPlayer.Position + 30 < _CurPlayer.Length || _PreviewStartHelperTask == null)
+            lock (_PreviewStartHelperTaskLock)
             {
-                lock (_PreviewStartHelperTaskLock)
+                _PreviewStartHelperTask = new Task(() =>
                 {
-                    _PreviewStartHelperTask = new Task(() =>
-                    {
-                        float length = _PreviewPlayer.Length;
-                        if (length < 1)
-                            length = 30; // If length is unknow or invalid assume a length of 30s
+                    float length = _PreviewPlayer.Length;
+                    if (length < 1)
+                        length = 30; // If length is unknow or invalid assume a length of 30s
 
-                        if (start < 0)
-                            start = (song.Preview.Source == EDataSource.None) ? length / 4f : song.Preview.StartTime;
-                        if (start > length - 5f)
-                            start = Math.Max(0f, Math.Min(length / 4f, length - 5f));
-                        if (start >= 0.5f)
-                            start -= 0.5f;
+                    if (start < 0)
+                        start = (song.Preview.Source == EDataSource.None) ? length / 4f : song.Preview.StartTime;
+                    if (start > length - 5f)
+                        start = Math.Max(0f, Math.Min(length / 4f, length - 5f));
+                    if (start >= 0.5f)
+                        start -= 0.5f;
 
-                        _PreviewPlayer.Position = start;
-                        Play();
-                    });
-                }
-                _CurPlayer = _PreviewPlayer;
+                    _PreviewPlayer.Position = start;
+                    Play();
+                });
             }
-            else
-            {
-                if (_PreviewStartHelperTask != null)
-                {
-                    lock (_PreviewStartHelperTaskLock)
-                    {
-                        // Recheck the condition as it cloud have change before we got the lock
-                        if (_PreviewStartHelperTask != null)
-                        {
-                            _PreviewStartHelperTask = null;
-                        }
-                    }
-                }
-                _PreviewPlayer.Position = _CurPlayer.Position;
-                _CurPlayer = _PreviewPlayer;
-                Play();
-            }
-
-            
-
-            
+            _CurPlayer = _PreviewPlayer;
         }
 
         public static void StopPreview()

--- a/Vocaluxe/Screens/CScreenHighscore.cs
+++ b/Vocaluxe/Screens/CScreenHighscore.cs
@@ -245,10 +245,16 @@ namespace Vocaluxe.Screens
                 _Scores = new List<SDBScoreEntry>[4];
                 int songID = CScreenSong.getSelectedSongID();
                 EHighscoreStyle style = CBase.Config.GetHighscoreStyle();
+                bool foundHighscoreEntries = false;
 
                 for (int gameModeNum = 0; gameModeNum < 4; gameModeNum++)
                 {
                     _Scores[gameModeNum] = CDataBase.LoadScore(songID, (EGameMode)gameModeNum, style);
+                    if (!foundHighscoreEntries && _Scores[gameModeNum].Count > 0)
+                    {
+                        _Round = gameModeNum;
+                        foundHighscoreEntries = true;
+                    }
                 }
             }
             else

--- a/Vocaluxe/Screens/CScreenHighscore.cs
+++ b/Vocaluxe/Screens/CScreenHighscore.cs
@@ -243,7 +243,7 @@ namespace Vocaluxe.Screens
                 _FromScreenSong = true;
                 _Round = (int)EGameMode.TR_GAMEMODE_NORMAL;
                 _Scores = new List<SDBScoreEntry>[4];
-                int songID = CSongs.VisibleSongs[CScreenSong.getSelectedSongID()].ID;
+                int songID = CScreenSong.getSelectedSongID();
                 EHighscoreStyle style = CBase.Config.GetHighscoreStyle();
 
                 for (int gameModeNum = 0; gameModeNum < 4; gameModeNum++)
@@ -272,7 +272,7 @@ namespace Vocaluxe.Screens
             
             CSong song;
             if (_FromScreenSong)
-                song = CSongs.GetSong(CSongs.VisibleSongs[CScreenSong.getSelectedSongID()].ID);
+                song = CSongs.GetSong(CScreenSong.getSelectedSongID());
             else
                 song = CGame.GetSong(_Round);
 
@@ -280,7 +280,7 @@ namespace Vocaluxe.Screens
                 return;
 
             _Texts[_TextSongName].Text = song.Artist + " - " + song.Title;
-            if (points != null && points.NumRounds > 1)
+            if (points != null && !_FromScreenSong && points.NumRounds > 1)
                 _Texts[_TextSongName].Text += " (" + (_Round + 1) + "/" + points.NumRounds + ")";
 
             switch ((_FromScreenSong ? (EGameMode)_Round : CGame.GetGameMode(_Round)))

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -42,7 +42,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 7; }
+            get { return 8; }
         }
 
         private const string _TextCategory = "TextCategory";
@@ -66,6 +66,7 @@ namespace Vocaluxe.Screens
         private const string _ButtonOptionsRandomMedley = "ButtonOptionsRandomMedley";
         private const string _ButtonOptionsStartMedley = "ButtonOptionsStartMedley";
         private const string _ButtonStart = "ButtonStart";
+        private const string _ButtonOptionsHighscore = "ButtonOptionsHighscore";
 
         private const string _SelectSlideOptionsMode = "SelectSlideOptionsMode";
         private const string _SelectSlideOptionsPlaylistAdd = "SelectSlideOptionsPlaylistAdd";
@@ -142,6 +143,7 @@ namespace Vocaluxe.Screens
             blist.Add(_ButtonStart);
             blist.Add(_ButtonOptionsRandomMedley);
             blist.Add(_ButtonOptionsStartMedley);
+            blist.Add(_ButtonOptionsHighscore);
 
             _TextsPlayer.Clear();
             for (int i = 0; i < CSettings.MaxNumPlayer; i++)
@@ -319,8 +321,7 @@ namespace Vocaluxe.Screens
                         case Keys.H:
                             if (keyEvent.Mod == EModifier.Ctrl && CSongs.NumSongsVisible > 0 && !_Sso.Selection.PartyMode)
                             {
-                                CScreenSong.setStaticSelectedSongID(_SongMenu.GetPreviewSongNr());
-                                CBase.Graphics.FadeTo(EScreen.Highscore);
+                                _ShowHighscore();
                             }
                             break;
                     }
@@ -419,6 +420,10 @@ namespace Vocaluxe.Screens
                         {
                             _ToggleSongOptions(ESongOptionsView.None);
                             _StartRandomMedley(_SelectSlides[_SelectSlideOptionsNumMedleySongs].Selection + 1, !CSongs.IsInCategory);
+                        }
+                        else if (_Buttons[_ButtonOptionsHighscore].Selected)
+                        {
+                            _ShowHighscore();
                         }
                         break;
 
@@ -594,6 +599,10 @@ namespace Vocaluxe.Screens
                         _ToggleSongOptions(ESongOptionsView.None);
                         _StartRandomMedley(_SelectSlides[_SelectSlideOptionsNumMedleySongs].Selection + 1, !CSongs.IsInCategory);
                         return true;
+                    }
+                    else if (_Buttons[_ButtonOptionsHighscore].Selected)
+                    {
+                        _ShowHighscore();
                     }
                     else if (_Sso.Selection.RandomOnly && _Sso.Selection.NumJokers != null)
                     {
@@ -882,6 +891,13 @@ namespace Vocaluxe.Screens
 
                 _Buttons[_ButtonStart].Visible = false;
             }
+        }
+
+        private void _ShowHighscore()
+        {
+            CGame.ClearSongs();
+            CScreenSong.setStaticSelectedSongID(CSongs.VisibleSongs[_SongMenu.GetPreviewSongNr()].ID);
+            CBase.Graphics.FadeTo(EScreen.Highscore);
         }
 
         private void _StartSong(int songNr)
@@ -1205,6 +1221,7 @@ namespace Vocaluxe.Screens
             _Buttons[_ButtonOptionsOpenSelectedItem].Visible = false;
             _Buttons[_ButtonOptionsRandomMedley].Visible = false;
             _Buttons[_ButtonOptionsStartMedley].Visible = false;
+            _Buttons[_ButtonOptionsHighscore].Visible = false;
             _Texts[_TextOptionsTitle].Visible = false;
             _Statics[_StaticOptionsBG].Visible = false;
             _Buttons[_ButtonOpenOptions].Visible = true;
@@ -1261,6 +1278,7 @@ namespace Vocaluxe.Screens
             _SelectSlides[_SelectSlideOptionsPlaylistAdd].Visible = true;
             _Buttons[_ButtonOptionsSing].Visible = true;
             _Buttons[_ButtonOptionsPlaylist].Visible = true;
+            _Buttons[_ButtonOptionsHighscore].Visible = true;
             _SelectElement(_Buttons[_ButtonOptionsSing]);
             _SetSelectSlidePlaylistToCurrentPlaylist();
         }

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -99,6 +99,18 @@ namespace Vocaluxe.Screens
         private ISongMenu _SongMenu;
         private CPlaylist _Playlist;
 
+        private static int _StaticSelectedSongID;
+
+        private static void setStaticSelectedSongID(int songID)
+        {
+            _StaticSelectedSongID = songID;
+        }
+
+        public static int getSelectedSongID()
+        {
+            return _StaticSelectedSongID;
+        }
+
         public override EMusicType CurrentMusicType
         {
             get { return CSongs.IsInCategory ? EMusicType.Preview : EMusicType.Background; }
@@ -302,6 +314,14 @@ namespace Vocaluxe.Screens
                         case Keys.S:
                             if (keyEvent.Mod == EModifier.Ctrl && CSongs.NumSongsVisible > 0 && !_Sso.Selection.PartyMode)
                                 _StartMedleySong(_SongMenu.GetPreviewSongNr());
+                            break;
+
+                        case Keys.H:
+                            if (keyEvent.Mod == EModifier.Ctrl && CSongs.NumSongsVisible > 0 && !_Sso.Selection.PartyMode)
+                            {
+                                CScreenSong.setStaticSelectedSongID(_SongMenu.GetPreviewSongNr());
+                                CBase.Graphics.FadeTo(EScreen.Highscore);
+                            }
                             break;
                     }
                     if (!_SearchActive)

--- a/VocaluxeLib/Menu/SongMenu/CSongMenuFramework.cs
+++ b/VocaluxeLib/Menu/SongMenu/CSongMenuFramework.cs
@@ -220,7 +220,7 @@ namespace VocaluxeLib.Menu.SongMenu
             EScreen check = CBase.Graphics.GetNextScreenType();
             if (CBase.Graphics.GetNextScreenType() == EScreen.Sing)
                 _ResetPreview(false);
-            else if (CBase.Graphics.GetNextScreenType() != EScreen.Names || CBase.Config.GetBackgroundMusicStatus() == EBackgroundMusicOffOn.TR_CONFIG_OFF)
+            else if ((CBase.Graphics.GetNextScreenType() != EScreen.Names && CBase.Graphics.GetNextScreenType() != EScreen.Highscore) || CBase.Config.GetBackgroundMusicStatus() == EBackgroundMusicOffOn.TR_CONFIG_OFF)
                 _ResetPreview();
         }
 


### PR DESCRIPTION
CTRL+H will show the highscores of the selected song.
If the highscores was opened from song screen, you can use the Arrow Left/Right keys to switch between the game modes Normal, Short, Medley and Duet.

Still some testing to do.

**Update from 25.01.2020**
Fixing preview sound interrupting / restart, when entering and leaving the Highscore.

If Highscores will be opened from song screen, switch to the first game mode with highscore entries.

New Highscore button after clicking on a song:
![image](https://user-images.githubusercontent.com/15168351/73118032-86d00480-3f4e-11ea-8e62-8747fcb81f6c.png)