### PR TITLE
Use page up/down to fast scroll the song screen

### DIFF
--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -363,6 +363,38 @@ namespace Vocaluxe.Screens
                                 _ShowHighscore();
                             }
                             break;
+
+                        case Keys.PageUp:
+                            if (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_OFF)
+                            {
+                                int numSongsPerPage = (CConfig.SongMenu == ESongMenu.TR_CONFIG_TILE_BOARD ? 24 : 15);
+                                if (keyEvent.Mod == EModifier.Ctrl)
+                                    _SongMenu.SetSelectedSong(0);
+                                else
+                                {
+                                    if ((_SongMenu.GetSelectedSongNr() - numSongsPerPage) <= 0)
+                                        _SongMenu.SetSelectedSong(0);
+                                    else
+                                        _SongMenu.SetSelectedSong(_SongMenu.GetSelectedSongNr() - numSongsPerPage);
+                                }
+                            }
+                            break;
+
+                        case Keys.PageDown:
+                            if (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_OFF)
+                            {
+                                int numSongsPerPage = (CConfig.SongMenu == ESongMenu.TR_CONFIG_TILE_BOARD ? 24 : 15);
+                                if (keyEvent.Mod == EModifier.Ctrl)
+                                    _SongMenu.SetSelectedSong(CSongs.NumSongsVisible - 1);
+                                else
+                                {
+                                    if ((_SongMenu.GetSelectedSongNr() + numSongsPerPage) >= CSongs.NumSongsVisible)
+                                        _SongMenu.SetSelectedSong(CSongs.NumSongsVisible - 1);
+                                    else
+                                        _SongMenu.SetSelectedSong(_SongMenu.GetSelectedSongNr() + numSongsPerPage);
+                                }
+                            }
+                            break;
                     }
                     if (!_SearchActive)
                     {


### PR DESCRIPTION
CTRL+Page Up/Down to go to first or last entry.
Page Up/Down to scroll one page up/down.
Only allowed if category / tabs view is disabled (because both keys have different functions in it).