### PR TITLE
Page UP/DOWN, HOME and END keys on Song screen (final implementation)

### DIFF
--- a/Output/Readme.txt
+++ b/Output/Readme.txt
@@ -142,7 +142,9 @@ Song screen
 [CTRL] + [V]			to sing all songs from a category
 [NUM_1]..[NUM_6]		to use a Joker for team 1..6
 [A]..[Z]			to jump to category/song title starting with that letters (multiple letters possible)
-[PAGE UP] or [PAGE DOWN]	if inside a category: Go up/down one category / if category view is disabled: Scroll one page up/down
+[PAGE UP] or [PAGE DOWN]	to scroll one page up/down
+[CTRL] + [PAGE UP or DOWN]	to go inside next or previous category while being in a category
+[HOME] or [END]			to scroll up to first song or down to last song
 
 Name selection screen
 [1]..[6]			to activate player selection.

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -363,38 +363,6 @@ namespace Vocaluxe.Screens
                                 _ShowHighscore();
                             }
                             break;
-
-                        case Keys.PageUp:
-                            if (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_OFF)
-                            {
-                                int numSongsPerPage = (CConfig.SongMenu == ESongMenu.TR_CONFIG_TILE_BOARD ? 24 : 15);
-                                if (keyEvent.Mod == EModifier.Ctrl)
-                                    _SongMenu.SetSelectedSong(0);
-                                else
-                                {
-                                    if ((_SongMenu.GetSelectedSongNr() - numSongsPerPage) <= 0)
-                                        _SongMenu.SetSelectedSong(0);
-                                    else
-                                        _SongMenu.SetSelectedSong(_SongMenu.GetSelectedSongNr() - numSongsPerPage);
-                                }
-                            }
-                            break;
-
-                        case Keys.PageDown:
-                            if (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_OFF)
-                            {
-                                int numSongsPerPage = (CConfig.SongMenu == ESongMenu.TR_CONFIG_TILE_BOARD ? 24 : 15);
-                                if (keyEvent.Mod == EModifier.Ctrl)
-                                    _SongMenu.SetSelectedSong(CSongs.NumSongsVisible - 1);
-                                else
-                                {
-                                    if ((_SongMenu.GetSelectedSongNr() + numSongsPerPage) >= CSongs.NumSongsVisible)
-                                        _SongMenu.SetSelectedSong(CSongs.NumSongsVisible - 1);
-                                    else
-                                        _SongMenu.SetSelectedSong(_SongMenu.GetSelectedSongNr() + numSongsPerPage);
-                                }
-                            }
-                            break;
                     }
                     if (!_SearchActive)
                     {

--- a/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
+++ b/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
@@ -344,17 +344,51 @@ namespace VocaluxeLib.Menu.SongMenu
                     break;
 
                 case Keys.PageUp:
-                    if (catChangePossible)
+                    if (catChangePossible && CBase.Songs.IsInCategory() && (keyEvent.Mod == EModifier.Ctrl || keyEvent.Mod == EModifier.Alt))
                     {
                         _PrevCategory();
+                        keyEvent.Handled = true;
+                    }
+                    else if (moveAllowed)
+                    {
+                        if ((_SelectionNr - _ListLength) <= 0)
+                            _SelectionNr = 0;
+                        else
+                            _SelectionNr = _SelectionNr - _ListLength;
                         keyEvent.Handled = true;
                     }
                     break;
 
                 case Keys.PageDown:
-                    if (catChangePossible)
+                    if (catChangePossible && CBase.Songs.IsInCategory() && (keyEvent.Mod == EModifier.Ctrl || keyEvent.Mod == EModifier.Alt))
                     {
                         _NextCategory();
+                        keyEvent.Handled = true;
+                    }
+                    else if (moveAllowed)
+                    {
+                        int maxCount_PageDown = (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_ON && !CBase.Songs.IsInCategory() ? CBase.Songs.GetNumCategories() : CBase.Songs.GetNumSongsVisible());
+                        if ((_SelectionNr + _ListLength) >= maxCount_PageDown)
+                            _SelectionNr = maxCount_PageDown - 1;
+                        else
+                            _SelectionNr = _SelectionNr + _ListLength;
+                        keyEvent.Handled = true;
+                    }
+                    break;
+
+                case Keys.Home:
+                    if (moveAllowed)
+                    {
+                        _SelectionNr = 0;
+                        keyEvent.Handled = true;
+                    }
+                    break;
+
+                case Keys.End:
+                    int maxCount_End = (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_ON && !CBase.Songs.IsInCategory() ? CBase.Songs.GetNumCategories() : CBase.Songs.GetNumSongsVisible());
+                    if (moveAllowed)
+                    {
+                        _SelectionNr = maxCount_End - 1;
                         keyEvent.Handled = true;
                     }
                     break;

--- a/VocaluxeLib/Menu/SongMenu/CSongMenuTileBoard.cs
+++ b/VocaluxeLib/Menu/SongMenu/CSongMenuTileBoard.cs
@@ -335,17 +335,53 @@ namespace VocaluxeLib.Menu.SongMenu
                     break;
 
                 case Keys.PageUp:
-                    if (catChangePossible)
+                    if (catChangePossible && CBase.Songs.IsInCategory() && (keyEvent.Mod == EModifier.Ctrl || keyEvent.Mod == EModifier.Alt))
                     {
                         _PrevCategory();
+                        keyEvent.Handled = true;
+                    }
+                    else if (moveAllowed)
+                    {
+                        int numSongsPerPage = _NumH * _NumW;
+                        if ((_SelectionNr - numSongsPerPage) <= 0)
+                            _SelectionNr = 0;
+                        else
+                            _SelectionNr = _SelectionNr - numSongsPerPage;
                         keyEvent.Handled = true;
                     }
                     break;
 
                 case Keys.PageDown:
-                    if (catChangePossible)
+                    if (catChangePossible && CBase.Songs.IsInCategory() && (keyEvent.Mod == EModifier.Ctrl || keyEvent.Mod == EModifier.Alt))
                     {
                         _NextCategory();
+                        keyEvent.Handled = true;
+                    }
+                    else if (moveAllowed)
+                    {
+                        int numSongsPerPage = _NumH * _NumW;
+                        int maxCount_PageDown = (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_ON && !CBase.Songs.IsInCategory() ? CBase.Songs.GetNumCategories() : CBase.Songs.GetNumSongsVisible());
+                        if ((_SelectionNr + numSongsPerPage) >= maxCount_PageDown)
+                            _SelectionNr = maxCount_PageDown - 1;
+                        else
+                            _SelectionNr = _SelectionNr + numSongsPerPage;
+                        keyEvent.Handled = true;
+                    }
+                    break;
+
+                case Keys.Home:
+                    if (moveAllowed)
+                    {
+                        _SelectionNr = 0;
+                        keyEvent.Handled = true;
+                    }
+                    break;
+
+                case Keys.End:
+                    int maxCount_End = (CBase.Songs.GetTabs() == EOffOn.TR_CONFIG_ON && !CBase.Songs.IsInCategory() ? CBase.Songs.GetNumCategories() : CBase.Songs.GetNumSongsVisible());
+                    if (moveAllowed)
+                    {
+                        _SelectionNr = maxCount_End - 1;
                         keyEvent.Handled = true;
                     }
                     break;


### PR DESCRIPTION
**Page UP/DOWN** keys are now working everywhere, where song selection is allowed, even at the categories (tabs view).
Moved CTRL + Page UP/DOWN function from pull request #468 to select the last and first entry to the keys **HOME** (Pos1) and **END** to have it similar to other programs. **HOME** and **END** keys are also working everywhere, where song selection is allowed.

Small change for the **Page UP/DOWN** keys compared to older Vocaluxe versions:
Within a category page up / down also just scroll down the list. To switch to the next / previous category, press **ALT + Page UP/DOWN** or **CTRL + Page UP/DOWN**. This makes the usage of Page UP/DOWN cleaner in my opinion.