### PR TITLE
Allow using space key while editing playlist names

### DIFF
--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -369,7 +369,7 @@ namespace Vocaluxe.Screens
                         switch (keyEvent.Key)
                         {
                             case Keys.Space:
-                                if (!_Sso.Selection.PartyMode)
+                                if (!_Sso.Selection.PartyMode && !_Playlist.isPlaylistNameEditMode())
                                     _ToggleSongOptions(ESongOptionsView.General);
                                 break;
 

--- a/VocaluxeLib/Menu/CPlaylist.cs
+++ b/VocaluxeLib/Menu/CPlaylist.cs
@@ -972,6 +972,11 @@ namespace VocaluxeLib.Menu
             return false;
         }
 
+        public bool isPlaylistNameEditMode()
+        {
+            return _EditMode == EEditMode.PlaylistName;
+        }
+
         private void _PrepareList()
         {
             _PlaylistElements.Clear();


### PR DESCRIPTION
Currently the song screen overwrites the use of the space key while editing the playlist name. Fixed it, so you can use the space character at the playlist names.