### PR TITLE
Key shortcut to show only songs of the current playlist (add #218)

### DIFF
--- a/Output/Readme.txt
+++ b/Output/Readme.txt
@@ -140,6 +140,7 @@ Song screen
 [CTRL] + [A]			to sing all songs
 [CTRL] + [S]			to sing current song in medley version
 [CTRL] + [V]			to sing all songs from a category
+[CTRL] + [L]			to filter the song list to the current displayed playlist. Press again to remove this filter.
 [NUM_1]..[NUM_6]		to use a Joker for team 1..6
 [A]..[Z]			to jump to category/song title starting with that letters (multiple letters possible)
 [PAGE UP] or [PAGE DOWN]	to scroll one page up/down

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -363,6 +363,13 @@ namespace Vocaluxe.Screens
                                 _ShowHighscore();
                             }
                             break;
+
+                        case Keys.L:
+                            if (keyEvent.Mod == EModifier.Ctrl)
+                            {
+                                _TogglePlaylistFilter();
+                            }
+                            break;
                     }
                     if (!_SearchActive)
                     {
@@ -869,9 +876,6 @@ namespace Vocaluxe.Screens
                 CParty.OnSongChange(_SelectedSongID, ref _Sso);
             }
 
-            _Sso = CParty.GetSongSelectionOptions();
-
-
             if (_Sso.Selection.PartyMode)
             {
                 CSongs.Sort(_Sso.Sorting.SongSorting, _Sso.Sorting.Tabs, _Sso.Sorting.IgnoreArticles, _Sso.Sorting.SearchString, _Sso.Sorting.DuetOptions, _Sso.Sorting.FilterPlaylistID);
@@ -1251,6 +1255,22 @@ namespace Vocaluxe.Screens
             // Stefan1200: Remember search string and current TickCount in class variables.
             _JumpTo_lastCharTime = Environment.TickCount;
             _JumpTo_lastSearchString = searchString;
+        }
+
+        public void _TogglePlaylistFilter()
+        {
+            if (_Sso.Sorting.FilterPlaylistID == _Playlist.ActivePlaylistID)
+            {
+                if (_Playlist.ActivePlaylistID == -1)
+                    return;
+
+                _Sso.Sorting.FilterPlaylistID = -1;
+            }
+            else
+                _Sso.Sorting.FilterPlaylistID = _Playlist.ActivePlaylistID;
+            
+            CSongs.Sort(_Sso.Sorting.SongSorting, _Sso.Sorting.Tabs, _Sso.Sorting.IgnoreArticles, _Sso.Sorting.SearchString, _Sso.Sorting.DuetOptions, _Sso.Sorting.FilterPlaylistID);
+            _SongMenu.OnShow();
         }
 
         private void _ApplyNewSearchFilter(string newFilterString)


### PR DESCRIPTION
CTRL+L while a playlist is open. It's a toggle key, just press again to return to normal list.
While filtered to a playlist, you can also use CTRL+L while the playlist is not open to switch back to the normal view.

Also fixed a small bug in _UpdatePartyModeOptions(), because it resets the current SongSelectionOptions by overwriting the _Sso variable every some milliseconds. Unknown if this has some side effects, but I guess not.

My initial plans included also a button on the playlist pane, to the left of the playlist save button. I was able to add this button and set events on it. But I don't know how to filter and refresh the song screen, while I'm in the CPlaylist class of the VocaluxeLib namespace. After playing around for hours I stopped trying this and added just this key shortcut.

Request by #218.