### PR TITLE
Read R (RAP) and G (Golden RAP) notes as Freestyle notes

### DIFF
--- a/VocaluxeLib/Songs/CSongLoader.cs
+++ b/VocaluxeLib/Songs/CSongLoader.cs
@@ -571,6 +571,8 @@ namespace VocaluxeLib.Songs
                             case ':':
                             case '*':
                             case 'F':
+                            case 'R':   // Read R (RAP) and G (Golden RAP) notes as Freestyle notes currently. Final implementation needed!
+                            case 'G':   // Read R (RAP) and G (Golden RAP) notes as Freestyle notes currently. Final implementation needed!
                                 string[] noteData = line.Split(splitChars, 4);
                                 if (noteData.Length < 4)
                                 {
@@ -618,7 +620,7 @@ namespace VocaluxeLib.Songs
 
                                     if (tag.Equals('*'))
                                         noteType = ENoteType.Golden;
-                                    else if (tag.Equals('F'))
+                                    else if (tag.Equals('F') || tag.Equals('R') || tag.Equals('G'))  // Read R (RAP) and G (Golden RAP) notes as Freestyle notes currently. Final implementation needed!
                                         noteType = ENoteType.Freestyle;
                                     else
                                         noteType = ENoteType.Normal;


### PR DESCRIPTION
Read R (RAP) and G (Golden RAP) notes as Freestyle notes currently. Final implementation needed!

As mentioned in #479 this fix the song loading of songs, which contains R or G notes. But Vocaluxe still don't support these kind of notes, so the final implementation is needed. If someone wants to work on it, feel free.