### PR TITLE
Fix X position calculation of cover and text on list song menu

### DIFF
--- a/Output/Themes/Genius/Screens/ScreenSong.xml
+++ b/Output/Themes/Genius/Screens/ScreenSong.xml
@@ -1004,16 +1004,16 @@
         <SpaceW>10</SpaceW>
         <SpaceH>10</SpaceH>
         <TileRect>
-          <X>375</X>
+          <X>410</X>
           <Y>42</Y>
-          <W>850</W>
+          <W>830</W>
           <H>555</H>
           <Z>-1</Z>
         </TileRect>
         <TileRectSmall>
-          <X>375</X>
+          <X>410</X>
           <Y>42</Y>
-          <W>450</W>
+          <W>410</W>
           <H>550</H>
           <Z>-1</Z>
         </TileRectSmall>

--- a/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
+++ b/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
@@ -176,12 +176,12 @@ namespace VocaluxeLib.Menu.SongMenu
             for (int i = 0; i < _ListLength; i++)
             {
                 //Create Cover
-                var rect = new SRectF(Rect.X + (_TileW + _SpaceW), Rect.Y + i * (_TileH + _SpaceH), _TileW, _TileH, Rect.Z);
+                var rect = new SRectF(Rect.X, Rect.Y + i * (_TileH + _SpaceH), _TileW, _TileH, Rect.Z);
                 var tile = new CStatic(_PartyModeID, _CoverBGTexture, _Color, rect);
                 _Tiles.Add(tile);
 
                 //Create text
-                var textRect = new SRectF(MaxRect.X + 2 * (_TileW + _SpaceW), Rect.Y + i * (_TileH + _SpaceH), _ListTextWidth, _TileH, Rect.Z);
+                var textRect = new SRectF(MaxRect.X + (_TileW + _SpaceW), Rect.Y + i * (_TileH + _SpaceH), _ListTextWidth, _TileH, Rect.Z);
                 CText text = new CText(textRect.X, textRect.Y, textRect.Z,
                                        textRect.H, textRect.W, EAlignment.Left, EStyle.Normal,
                                        "Normal", _Artist.Color, "");


### PR DESCRIPTION
Origin and now fixed problem:
If song menu list is activated, you was unable to click with the mouse on the right 25px of the song options like the right arrow of the playlist or game mode selection. The genius theme sets the X position behind the video preview and menus. The wrong value had no visible GUI impact, because the CSongMenuList.cs did a wrong calculation here.

On the screenshot you can see a red vertical line. Without this changes you are only able to click on the left side of this red line. On the right of it the song options menu just closes.
![image](https://user-images.githubusercontent.com/15168351/73747392-a5f14200-4757-11ea-8ae2-343550febd8d.png)

Tile song menu was already correct, so I just fixed the values for list song menu. Old Ambient theme (release 0.4.X) is also not affected of this bug.