### PR TITLE
Automatic Video Aspect now selects the best mode for widescreen

### DIFF
--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -842,7 +842,7 @@ namespace Vocaluxe.Screens
                     SRectF bounds = CSettings.RenderRect;
                     
                     if (_VideoAspect == EAspect.Automatic)
-                        _VideoAspect = (background.OrigAspect <= 1.5 ? EAspect.LetterBox : EAspect.Crop);
+                        _VideoAspect = ((background.OrigAspect <= 1.5 || background.OrigAspect >= 2.0) ? EAspect.LetterBox : EAspect.Crop);
                     aspect = _VideoAspect;
                     
                     SRectF rect = CHelper.FitInBounds(bounds, background.OrigAspect, aspect);


### PR DESCRIPTION
It now uses LetterBox on 2.29:1 and similar aspect ratio movies (e.g. 640x280).