### PR TITLE
Fix alpha calculation for last sub line

### DIFF
--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -1459,7 +1459,7 @@ namespace Vocaluxe.Screens
                 }
 
                 // sub
-                if (currentLineSub < lines.Length - 2)
+                if ((currentLineSub + 1) < lines.Length)
                 {
                     float diff = CGame.GetTimeFromBeats(lines[currentLineSub + 1].FirstNoteBeat, song.BPM) - currentTime;
 


### PR DESCRIPTION
Sub line was displayed wrong, if the last lyric line has a bigger distance to the second last line. Alpha calculation for sub lines stopped one line to early and might be visible even if it shouldn't be.