### PR TITLE
Adding PillarBox as own EAspect (fix #499)

### DIFF
--- a/VocaluxeLib/CHelper.cs
+++ b/VocaluxeLib/CHelper.cs
@@ -139,12 +139,7 @@ namespace VocaluxeLib
                     }
                     break;
                 case EAspect.LetterBox:
-                    if (boundsAspectRatio == aspectRatio)  // Pillarbox
-                    {
-                        scaledWidth = bounds.W * 0.77f;
-                        scaledHeight = bounds.W / aspectRatio;
-                    }
-                    else if (boundsAspectRatio < aspectRatio)
+                    if (boundsAspectRatio < aspectRatio)
                     {
                         scaledWidth = bounds.W;
                         scaledHeight = bounds.W / aspectRatio;
@@ -154,6 +149,10 @@ namespace VocaluxeLib
                         scaledHeight = bounds.H;
                         scaledWidth = bounds.H * aspectRatio;
                     }
+                    break;
+                case EAspect.PillarBox:
+                    scaledWidth = bounds.W * 0.77f;
+                    scaledHeight = bounds.W / aspectRatio;
                     break;
                 default:
                     return bounds;

--- a/VocaluxeLib/Enums.cs
+++ b/VocaluxeLib/Enums.cs
@@ -67,6 +67,7 @@ namespace VocaluxeLib
         Automatic,
         Crop,
         LetterBox,
+        PillarBox,
         Stretch,
         Zoom1,
         Zoom2


### PR DESCRIPTION
Prior this change PillarBox was made in a special case at LetterBox, but that has an effect on the cover image creation.
Fix #499 

File **CoverDB.sqlite** should be deleted, so cover images will be recreated!