### PR TITLE
Fix: replace invalid github tokens in 0.4.1 branch

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ platform:
 clone_depth: 15
 environment:
   GitHubKey:
-    secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
+    secure: sGetWh2XUYs95VBT+QYNPtDW9Rh2/JBuxNNYXytpn7mMudUMcjSKDGErkCTum+ZE
 install:
 - ps: |
     $Env:CurrentCommitSha = "$(git rev-parse --verify HEAD)"
@@ -88,7 +88,7 @@ deploy:
   release: $(APPVEYOR_REPO_TAG_NAME)
   description: $(APPVEYOR_REPO_COMMIT)
   auth_token:
-    secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
+    secure: sGetWh2XUYs95VBT+QYNPtDW9Rh2/JBuxNNYXytpn7mMudUMcjSKDGErkCTum+ZE
   artifact: ReleaseZip
   prerelease: $(IS_BETA_RELEASE)
   on:
@@ -100,7 +100,7 @@ deploy:
   release: Latest Nightly build
   description: $(APPVEYOR_REPO_COMMIT)
   auth_token:
-    secure: JSlN/em0JdspVn8jwaQ4IjugY6OQi0au4Qq0rhctJmcfGMaEGnUAOmDFULI48REW
+    secure: sGetWh2XUYs95VBT+QYNPtDW9Rh2/JBuxNNYXytpn7mMudUMcjSKDGErkCTum+ZE
   artifact: ReleaseZip
   prerelease: true
   on:


### PR DESCRIPTION
Should fix the release problem - after you have merged this you need to move the 0.4.1 tag to trigger a working build.