### PR TITLE
sort by initial letter first when sorting by letter

### DIFF
--- a/Vocaluxe/Base/CSongSorter.cs
+++ b/Vocaluxe/Base/CSongSorter.cs
@@ -111,6 +111,24 @@ namespace Vocaluxe.Base
             return res;
         }
 
+        /// <summary>
+        /// Compares two songs by means of: first letter of sorting field, sorting field, title.
+        /// </summary>
+        private int _SortByLetterFieldTitle(CSongPointer s1, CSongPointer s2)
+        {
+            int res = String.Compare(s1.SortString[0].ToString(), s2.SortString[0].ToString(), StringComparison.CurrentCultureIgnoreCase);
+            return res != 0 ? res : _SortByFieldTitle(s1, s2);
+        }
+
+        /// <summary>
+        /// Compares two songs by means of: first letter of sorting field, sorting field, artist, title.
+        /// </summary>
+        private int _SortByLetterFieldArtistTitle(CSongPointer s1, CSongPointer s2)
+        {
+            int res = String.Compare(s1.SortString[0].ToString(), s2.SortString[0].ToString(), StringComparison.CurrentCultureIgnoreCase);
+            return res != 0 ? res : _SortByFieldArtistTitle(s1, s2);
+        }
+
         private void _AddSongToList(CSong song, List<CSongPointer> list)
         {
             string value = null;
@@ -172,10 +190,15 @@ namespace Vocaluxe.Base
                 _AddSongToList(song, sortList);
             switch (_SongSorting)
             {
-                case ESongSorting.TR_CONFIG_ARTIST_LETTER:
                 case ESongSorting.TR_CONFIG_ARTIST:
                 case ESongSorting.TR_CONFIG_NONE:
                     sortList.Sort(_SortByFieldTitle);
+                    break;
+                case ESongSorting.TR_CONFIG_ARTIST_LETTER:
+                    sortList.Sort(_SortByLetterFieldTitle);
+                    break;
+                case ESongSorting.TR_CONFIG_TITLE_LETTER:
+                    sortList.Sort(_SortByLetterFieldArtistTitle);
                     break;
                 default:
                     sortList.Sort(_SortByFieldArtistTitle);


### PR DESCRIPTION
When sorting is set to "by title/artist letter", sort by means of initial letter of title/artist first before comparing the whole sorting string (fixes #514).

Note that this is not equivalent due to culture sensitive sorting:
Old sorting: "aa", "äa", "az"
New sorting: "aa", "az", "äa"