### PR TITLE
SongMenuList - Show song title first if title letter sorting is active

### DIFF
--- a/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
+++ b/VocaluxeLib/Menu/SongMenu/CSongMenuList.cs
@@ -678,7 +678,11 @@ namespace VocaluxeLib.Menu.SongMenu
                     {
                         CSong currentSong = CBase.Songs.GetVisibleSong(i + offset);
                         _Tiles[i].Texture = currentSong.CoverTextureSmall;
-                        _Texts[i].Text = currentSong.Artist + " - " + currentSong.Title;
+                        
+                        if (CBase.Config.GetSongSorting() == ESongSorting.TR_CONFIG_TITLE_LETTER)
+                            _Texts[i].Text = currentSong.Title + " - " + currentSong.Artist;
+                        else
+                            _Texts[i].Text = currentSong.Artist + " - " + currentSong.Title;
                     }
                     else
                     {


### PR DESCRIPTION
Change for the Song Menu list style, displaying title first, if sorted using tittle letter.
![image](https://user-images.githubusercontent.com/15168351/93012481-1a6b4980-f5a1-11ea-9704-e45e932724de.png)

Change for #531