### PR TITLE
Set preview song as selected song if entering the highscore of that song

### DIFF
--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1000,6 +1000,7 @@ namespace Vocaluxe.Screens
         {
             CGame.ClearSongs();
             CScreenSong.setStaticSelectedSongID(CSongs.VisibleSongs[_SongMenu.GetPreviewSongNr()].ID);
+            _SongMenu.SetSelectedSong(_SongMenu.GetPreviewSongNr());
             CBase.Graphics.FadeTo(EScreen.Highscore);
         }
 


### PR DESCRIPTION
This should make sure, that the song is still selected and will be previewed without interruption after closing the high score.
Should fix #506 

@daggeg Please test, if this fix your issue.