### PR TITLE
Fix crash on an ArgumentException from Party Modes

### DIFF
--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -430,7 +430,13 @@ namespace Vocaluxe.Screens
             _SetPause(false);
 
             _TimeRects.Clear();
-            _Sso = CParty.GetSongSelectionOptions();
+            try
+            {
+                _Sso = CParty.GetSongSelectionOptions();
+            }
+            catch (ArgumentException)
+            {
+            }
 
             _SingNotes[_SingBars].Init(0);
             _AssignPlayerElements();


### PR DESCRIPTION
Well, not using party modes on my end, but this pull request fixes the crash on start singing within TicTacToe party mode. But it is more testing needed, if the TicTacToe party mode itself still works as expected. I just compared it with Vocaluxe 0.4.0 and it seems to work like the same.

Fixes #550 