### PR TITLE
Assuming playing party mode on ArgumentException

### DIFF
--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -436,6 +436,8 @@ namespace Vocaluxe.Screens
             }
             catch (ArgumentException)
             {
+                // Workaround to assume party mode here (TicTacToe game mode throw the ArgumentException) / Stefan1200
+                _Sso.Selection.PartyMode = true;
             }
 
             _SingNotes[_SingBars].Init(0);

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -436,7 +436,7 @@ namespace Vocaluxe.Screens
             }
             catch (ArgumentException)
             {
-                // Workaround to assume party mode here (TicTacToe game mode throw the ArgumentException) / Stefan1200
+                // Workaround to assume party mode here (TicTacToe party mode throw the ArgumentException) / Stefan1200
                 _Sso.Selection.PartyMode = true;
             }
 


### PR DESCRIPTION
If getting an ArgumentException while requesting song selection options (which the TicTacToe party mode do), I assume that Vocaluxe is playing a party mode.
This allows detection of a running party mode in CScreenSing, to prevent song skipping (Shift/CTRL + Arrow Right) while playing party modes.