### PR TITLE
Change: Default encoding to UTF-8 without bom

### DIFF
--- a/VocaluxeLib/Songs/CSong.cs
+++ b/VocaluxeLib/Songs/CSong.cs
@@ -88,7 +88,7 @@ namespace VocaluxeLib.Songs
 
         public SShortEnd ShortEnd;
 
-        public Encoding Encoding = Encoding.Default;
+        public Encoding Encoding = UTF8Encoding.UTF8Encoding();
         public bool ManualEncoding;
         public string Folder = String.Empty;
         public string FolderName = String.Empty;


### PR DESCRIPTION
@bohning requested to change the song-loading to UTF-8 without bom as a default. As I don't have a working setup with Visual Studio anymore (as I've switched to a MacBook), let's see if we can get a testable state with our CI.