### PR TITLE
#559 Display song name on sing screen in pause menu

### DIFF
--- a/Output/Themes/Changelog/Changelog_ScreenSing.txt
+++ b/Output/Themes/Changelog/Changelog_ScreenSing.txt
@@ -1,6 +1,19 @@
 ScreenSing
 
 +++++++++
+Version 11
+
+Add:
+<TextPauseSongName>
+
++++++++++
+Version 10
+
+Add:
+<StaticShortInfoTop>
+<TextShortInfoTop>
+
++++++++++
 Version 9
 
 Add:

--- a/Output/Themes/Genius/Screens/ScreenSing.xml
+++ b/Output/Themes/Genius/Screens/ScreenSing.xml
@@ -694,6 +694,20 @@
       <Font>Outline</Font>
       <Text>TR_SCREENSING_PAUSE</Text>
     </Text>
+    <Text Name="TextPauseSongName">
+      <X>640</X>
+      <Y>10</Y>
+      <Z>-2.11</Z>
+      <H>40</H>
+      <MaxW>0</MaxW>
+      <Color Name="White" />
+      <SelColor Name="White" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Normal</Font>
+      <Text></Text>
+    </Text>
     <Text Name="TextDuetName1">
       <X>10</X>
       <Y>55</Y>

--- a/Output/Themes/Genius/Screens/ScreenSing.xml
+++ b/Output/Themes/Genius/Screens/ScreenSing.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenSing</ScreenName>
-    <ScreenVersion>10</ScreenVersion>
+    <ScreenVersion>11</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -41,7 +41,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 10; }
+            get { return 11; }
         }
 
         private struct STimeRect

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -57,6 +57,7 @@ namespace Vocaluxe.Screens
         private const string _TextDuetName1 = "TextDuetName1";
         private const string _TextDuetName2 = "TextDuetName2";
         private const string _TextMedleyCountdown = "TextMedleyCountdown";
+        private const string _TextPauseSongName = "TextPauseSongName";
         private string[,,] _TextScores;
         private string[,,] _TextNames;
         private List<string> _TextsPause;
@@ -1114,6 +1115,13 @@ namespace Vocaluxe.Screens
             _Buttons[_ButtonRestartGame].Visible = _Pause;
             _Buttons[_ButtonRestartRound].Visible = _Pause && CGame.NumRounds > 1;
 
+            if (_Pause && _TimerSongText.IsRunning)            
+                _TimerSongText.Stop();
+            else            
+                _TimerSongText.Start();
+
+            _Texts[_TextSongName].Visible = !_Pause;
+
             if (_Pause)
                 CSound.Pause(_CurrentStream);
             else
@@ -1149,6 +1157,7 @@ namespace Vocaluxe.Screens
             if (rounds > 1)
                 songname += " (" + CGame.RoundNr + "/" + rounds + ")";
             _Texts[_TextSongName].Text = songname;
+            _Texts[_TextPauseSongName].Text = songname;
 
             _CurrentStream = CSound.Load(song.GetMP3(), false, true, CConfig.Config.Sound.KaraokeEffect == EOffOn.TR_CONFIG_ON ? EAudioEffect.Karaoke : EAudioEffect.None);
             CSound.SetStreamVolume(_CurrentStream, 100);


### PR DESCRIPTION
### Goal:
Display song name on sing screen in pause menu

### Screenshot:
![image](https://github.com/Vocaluxe/Vocaluxe/assets/25153590/2e3db545-5d78-4be6-82ca-2bba58e980a1)
