### PR TITLE
Add ability to search by #TAGS

### DIFF
--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -155,7 +155,7 @@
   <string name="TR_SCREENSONG_NUMSONG">(%v song)</string>
   <string name="TR_SCREENSONG_ARTIST_TITLE">%a - %t</string>
   <string name="TR_SCREENSONG_HELPMESSAGE">A-Z = Jump to the letter • F3 = Search • CTRL+R = Random selection • CTRL+S = Start medley • CTRL+# = Change song sorting • CTRL+T = Enable/Disable category view • Space = Open song options • ESC = Back to main menu</string>
-  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name</string>
+  <string name="TR_SCREENSONG_HELPMESSAGESEARCH">A-Z = Search artist and title, prefixes for the search → a: = artist • t: = title • c: = creator • e: = edition • g: = genre • y: = year (e.g. 1999 or 1980-1989) • l: = language • al: = album • fi: = file name • fo: = folder name • #: = tags</string>
   <string name="TR_SCREENSONG_HELPMESSAGEPARTY">1-6 = Press your team number to use a random song joker</string>
   <string name="TR_SCREENSONG_SORTING">Sorting: %s</string>
   <string name="TR_SCREENSONG_NOMEDLEY">No Medley for this song!</string>

--- a/Vocaluxe/Base/CSongFilter.cs
+++ b/Vocaluxe/Base/CSongFilter.cs
@@ -100,6 +100,7 @@ namespace Vocaluxe.Base
             String searchForLanguage = null;    // l:
             String searchForCreator = null;     // c:
             String searchForEdition = null;     // e:
+            String searchForTags = null;        // #:
             String searchForAlbum = null;       // al:
             String searchForFileName = null;    // fi:
             String searchForFolderName = null;  // fo:
@@ -137,6 +138,9 @@ namespace Vocaluxe.Base
                             break;
                         case "E:":
                             searchForEdition = searchToken.Substring(2);
+                            break;
+                        case "#:":
+                            searchForTags = searchToken.Substring(2);
                             break;
                         default:
                             foundIt = false;
@@ -227,6 +231,15 @@ namespace Vocaluxe.Base
                             foreach (String edition in song.Editions)
                             {
                                 if (edition.ToUpper().Contains(searchForEdition))
+                                    _FilteredSongs.Add(song);
+                            }
+                        }
+
+                        if (searchForTags != null)
+                        {
+                            foreach (String tag in song.Tags)
+                            {
+                                if (tag.ToUpper().Contains(searchForTags))
                                     _FilteredSongs.Add(song);
                             }
                         }


### PR DESCRIPTION
**Description**

Resolves #690 

The ability to search using the #TAGS attribute has been added, using `#` as the keyword in the advanced search. This was done by simply adding a new case to the search algorithm, mimicking that of the search by genre.

Currently, this new functionality does no appear in the help menu at the bottom: that would require updating the [language files](https://github.com/Vocaluxe/Vocaluxe/tree/cd0e5223cd320f12222ac703a6de0ce53bb4b5ed/Output/Languages) and I do not have the skills to update anything other than English. Furthermore, I'm unsure if an additional help would even fit on the screen. How would you like to handle this?

**To Test**

Please do have a look since I had to partially hack my local build of Vocaluxe to get it to compile and work at all.

1. Open the search using F3
2. Type in `#:` following a string of letters that match a #TAGS attribute in one of your songs; the matching songs should show up.