### PR TITLE
Fix delayed perfect line effect

### DIFF
--- a/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
+++ b/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
@@ -145,10 +145,10 @@ namespace VocaluxeLib.Menu.SingNotes
                 }
             }
 
-            if (_CurrentLine > 0 && sungLines.Last().PerfectLine)
+            if (_CurrentLine > 0 && sungLines[sungLines.Count-1].PerfectLine)
             {
                 _AddPerfectLine();
-                sungLines.Last().PerfectLine = false;
+                sungLines[sungLines.Count-1].PerfectLine = false;
             }
 
             _Flares.RemoveAll(el => !el.IsAlive);
@@ -237,7 +237,7 @@ namespace VocaluxeLib.Menu.SingNotes
             CBase.Drawing.DrawTexture(toneHelper, drawRect, color, false);
         }
 
-        private void _DrawNote(SRectF rect, SColorF color, CTextureRef noteBegin, CTextureRef noteMiddle, CTextureRef noteEnd, float factor)
+        private static void _DrawNote(SRectF rect, SColorF color, CTextureRef noteBegin, CTextureRef noteMiddle, CTextureRef noteEnd, float factor)
         {
             if (factor <= 0)
                 return;

--- a/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
+++ b/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
@@ -145,10 +145,10 @@ namespace VocaluxeLib.Menu.SingNotes
                 }
             }
 
-            if (_CurrentLine > 0 && sungLines.Count >= _CurrentLine && sungLines[_CurrentLine - 1].PerfectLine)
+            if (_CurrentLine > 0 && sungLines.Last().PerfectLine)
             {
                 _AddPerfectLine();
-                sungLines[_CurrentLine - 1].PerfectLine = false;
+                sungLines.Last().PerfectLine = false;
             }
 
             _Flares.RemoveAll(el => !el.IsAlive);

--- a/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
+++ b/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
@@ -145,10 +145,10 @@ namespace VocaluxeLib.Menu.SingNotes
                 }
             }
 
-            if (_CurrentLine > 0 && sungLines[sungLines.Count-1].PerfectLine)
+            if (sungLines.Count > 0 && sungLines[sungLines.Count - 1].PerfectLine)
             {
                 _AddPerfectLine();
-                sungLines[sungLines.Count-1].PerfectLine = false;
+                sungLines[sungLines.Count - 1].PerfectLine = false;
             }
 
             _Flares.RemoveAll(el => !el.IsAlive);


### PR DESCRIPTION
A visual bug that has bothered me for a while where the sparkly effects aafter a perfect line gets delayed if the next line starts long after the perfect line ends.

Demo of current behaviour vs new behaviour attached. (We also seem to have the little helper dot off by an octave occasionally.)

https://github.com/user-attachments/assets/73ac79a9-a8f4-4340-9fc8-2d971cb5cc51

