### PR TITLE
Fix Animation for Progress Bar on Score Screen

### DIFF
--- a/VocaluxeLib/Menu/CProgressBar.cs
+++ b/VocaluxeLib/Menu/CProgressBar.cs
@@ -131,6 +131,7 @@ namespace VocaluxeLib.Menu
             get { return _ProgressTarget; }
             set
             {
+                _ProgressLast = 0;
                 //Animation is still running, so use current state for calculations
                 if(_ProgressCurrent != _ProgressTarget)
                 {


### PR DESCRIPTION
**Current Issue:**
When a player scores points on a song, the rating bar correctly animates from 0 up to the player’s score. However, if the player immediately repeats the song and scores lower than before, the rating bar animates downward from the previous score to the new score, rather than starting from 0.

**Solution:**
This fix ensures that the rating bar always starts animating from 0