### PR TITLE
Additional fix for #725 (Fix Animation for Progress Bar on Score Screen)

### DIFF
--- a/VocaluxeLib/Menu/CProgressBar.cs
+++ b/VocaluxeLib/Menu/CProgressBar.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -132,6 +132,7 @@ namespace VocaluxeLib.Menu
             set
             {
                 _ProgressLast = 0;
+                _AnimTimer.Reset();
                 //Animation is still running, so use current state for calculations
                 if(_ProgressCurrent != _ProgressTarget)
                 {


### PR DESCRIPTION
The Animation Timer also requires a reset. Otherwise the animation plays too quickly the second time the screen is displayed.

Apologies for the oversight in the initial fix.