### PR TITLE
fix: adjust rendering box for large characters

### DIFF
--- a/Vocaluxe/Base/Fonts/CGlyph.cs
+++ b/Vocaluxe/Base/Fonts/CGlyph.cs
@@ -53,7 +53,7 @@ namespace Vocaluxe.Base.Fonts
                     //Gets exact height and width for drawing more than 1 char. But width is to small to draw char on bitmap as e.g. italic chars will get cropped
                     //See https://stackoverflow.com/questions/11708621/how-to-measure-width-of-a-string-precisely
                     StringFormat format = StringFormat.GenericTypographic;
-                    RectangleF rect = new RectangleF(0, 0, 1000, 1000);
+                    RectangleF rect = new RectangleF(0, 0, 2000, 2000);
                     CharacterRange[] ranges = { new CharacterRange(0, chrString.Length) };
                     format.SetMeasurableCharacterRanges(ranges);
                     _BoundingBox = g.MeasureCharacterRanges(chrString, fo, rect, format)[0].GetBounds(g).Size;


### PR DESCRIPTION
Trying to fix #728. My idea is the following:
- Characters are rendered not directly but for every character (including digits) is rendered in it's max size and stored inside a texture list. These textures (Glyphs) are used for displaying texts.
- During medleys a countdown with big numbers is shown
- For rendering of the glyphs, we use for technically reasons a 1000x1000 box
- this box is (hopefully) too small after increasing the rendering size
- After singing a medley the digit glyphs are someway corrupt

I've increased the box to fix that hopefully.