### PR TITLE
Fix tone helper drawn on wrong octave

### DIFF
--- a/Vocaluxe/Base/CMain.cs
+++ b/Vocaluxe/Base/CMain.cs
@@ -571,6 +571,11 @@ namespace Vocaluxe.Base
             return CGame.GetPoints();
         }
 
+        public int GetCurrentBeat()
+        {
+            return CGame.CurrentBeat;
+        }
+
         public float GetMidRecordedBeat()
         {
             return CGame.MidRecordedBeat;

--- a/VocaluxeLib/IBasic.cs
+++ b/VocaluxeLib/IBasic.cs
@@ -188,6 +188,7 @@ namespace VocaluxeLib
         void SetNumPlayer(int numPlayer);
         SPlayer[] GetPlayers();
         CPoints GetPoints();
+        int GetCurrentBeat();
         float GetMidRecordedBeat();
         int GetRecordedBeat();
 

--- a/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
+++ b/VocaluxeLib/Menu/SingNotes/CNoteBars.cs
@@ -102,7 +102,6 @@ namespace VocaluxeLib.Menu.SingNotes
 
             var color = new SColorF(_Color, _Color.A * Alpha);
 
-            float baseLine = line.BaseLine;
             foreach (CSongNote note in line.Notes)
             {
                 if (note.Type != ENoteType.Freestyle)
@@ -115,7 +114,7 @@ namespace VocaluxeLib.Menu.SingNotes
             }
 
             if (CBase.Config.GetDrawToneHelper() == EOffOn.TR_CONFIG_ON)
-                _DrawToneHelper((int)baseLine, (CBase.Game.GetMidRecordedBeat() - line.FirstNoteBeat) / beats * Rect.W);
+                _DrawToneHelper(line, (CBase.Game.GetMidRecordedBeat() - line.FirstNoteBeat) / beats * Rect.W);
 
             List<CSungLine> sungLines = CBase.Game.GetPlayers()[_Player].SungLines;
             if (_CurrentLine >= 0 && _CurrentLine < sungLines.Count)
@@ -202,14 +201,16 @@ namespace VocaluxeLib.Menu.SingNotes
             }
         }
 
-        private void _DrawToneHelper(int baseLine, float offsetX)
+        private void _DrawToneHelper(CSongLine line, float offsetX)
         {
             int tonePlayer = CBase.Record.GetToneAbs(_Player);
+            int noteIndex = line.FindPreviousNote(CBase.Game.GetCurrentBeat()).Clamp(0,line.Notes.Count()-1);
+            int note = line.Notes[noteIndex].Tone;
 
-            while (tonePlayer - baseLine < 0)
+            while (tonePlayer - note < -6)
                 tonePlayer += 12;
 
-            while (tonePlayer - baseLine > 12)
+            while (tonePlayer - note > 6)
                 tonePlayer -= 12;
 
             if (offsetX < 0f)
@@ -220,7 +221,7 @@ namespace VocaluxeLib.Menu.SingNotes
 
             var drawRect = new SRectF(
                 Rect.X - _NoteLineHeight + offsetX,
-                Rect.Y + _NoteLineHeight * (CBase.Settings.GetNumNoteLines() - 1 - (tonePlayer - baseLine) / 2f),
+                Rect.Y + _NoteLineHeight * (CBase.Settings.GetNumNoteLines() - 1 - (tonePlayer - line.BaseLine) / 2f),
                 _NoteLineHeight,
                 _NoteLineHeight,
                 Rect.Z


### PR DESCRIPTION
This change addresses the behaviour of which the tone helper is drawn on the wrong octave when singing a line containing notes that span past the first octave from the baseline note. The faulty behaviour was noted in the demo for #704.

The tone helper will be clamped to within one octave of the target note.