### PR TITLE
Same position for rap notes

### DIFF
--- a/VocaluxeLib/Songs/CBaseNote.cs
+++ b/VocaluxeLib/Songs/CBaseNote.cs
@@ -68,7 +68,13 @@ namespace VocaluxeLib.Songs
 
         public int Tone
         {
-            get { return _Tone; }
+            get
+            {
+                // Always return 0 for Rap notes
+                if (IsRapNote)
+                    return 0;
+                return _Tone;
+            }
             set
             {
                 if ((value >= CBase.Settings.GetToneMin()) && (value <= CBase.Settings.GetToneMax()))


### PR DESCRIPTION
This sets all rap notes to the same position/tone.

See #718:
"all rap notes need to have same position, since pitch doesn't count"