### PR TITLE
Graphics Options

### DIFF
--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -209,6 +209,7 @@
   <string name="TR_SCREENO_BUTTON_LYRICS">Lyrics/Graphics</string>
   <string name="TR_SCREENO_BUTTON_THEME">Theme</string>
   <string name="TR_SCREENO_BUTTON_CREDITS">Credits</string>
+  <string name="TR_SCREENO_WARNINGRESTART">Please restart the game for the changes to take effect.</string>
   <string name="TR_SCREENOGAME_BUTTON_SERVER">Server address</string>
   <string name="TR_SCREENOGAME_OPTIONS">Game Options</string>
   <string name="TR_SCREENOGAME_LANGUAGE">Language</string>
@@ -253,7 +254,6 @@
   <string name="TR_SCREENOLYRICS_STYLE">Animation style</string>
   <string name="TR_SCREENOLYRICS_POSITION">Lyrics position</string>
   <string name="TR_SCREENOGRAPHICS_OPTIONS">Graphics Options</string>
-  <string name="TR_SCREENOGRAPHICS_WARNINGRESTART">Please restart the game for some graphical changes to take effect.</string>
   <string name="TR_SCREENOGRAPHICS_TEXTUREQUALITY">Texture quality</string>
   <string name="TR_SCREENOGRAPHICS_COVERSIZE">Cover size (pixels)</string>
   <string name="TR_SCREENOGRAPHICS_FULLSCREEN">Fullscreen</string>

--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -206,7 +206,7 @@
   <string name="TR_SCREENO_BUTTON_SOUND">Sound</string>
   <string name="TR_SCREENO_BUTTON_RECORD">Record</string>
   <string name="TR_SCREENO_BUTTON_VIDEO">Video</string>
-  <string name="TR_SCREENO_BUTTON_LYRICS">Lyrics</string>
+  <string name="TR_SCREENO_BUTTON_LYRICS">Lyrics/Graphics</string>
   <string name="TR_SCREENO_BUTTON_THEME">Theme</string>
   <string name="TR_SCREENO_BUTTON_CREDITS">Credits</string>
   <string name="TR_SCREENOGAME_BUTTON_SERVER">Server address</string>
@@ -252,6 +252,12 @@
   <string name="TR_SCREENOLYRICS_OPTIONS">Lyrics Options</string>
   <string name="TR_SCREENOLYRICS_STYLE">Animation style</string>
   <string name="TR_SCREENOLYRICS_POSITION">Lyrics position</string>
+  <string name="TR_SCREENOGRAPHICS_OPTIONS">Graphics Options</string>
+  <string name="TR_SCREENOGRAPHICS_WARNINGRESTART">Please restart the game for some graphical changes to take effect.</string>
+  <string name="TR_SCREENOGRAPHICS_TEXTUREQUALITY">Texture quality</string>
+  <string name="TR_SCREENOGRAPHICS_COVERSIZE">Cover size (pixels)</string>
+  <string name="TR_SCREENOGRAPHICS_FULLSCREEN">Fullscreen</string>
+  <string name="TR_SCREENOGRAPHICS_STRETCH">Stretched</string>
   <string name="TR_SCREENOVIDEO_OPTIONS">Video Options</string>
   <string name="TR_SCREENOVIDEO_VIDEOBACKGROUNDS">Video backgrounds</string>
   <string name="TR_SCREENOVIDEO_VIDEOPREVIEW">Video preview</string>

--- a/Output/Themes/Changelog/Changelog_ScreenOptionsLyrics.txt
+++ b/Output/Themes/Changelog/Changelog_ScreenOptionsLyrics.txt
@@ -1,7 +1,19 @@
-ScreenOptionsSound
+ScreenOptionsLyrics
+
+++++++++++
+Version 3:
+
+Add Graphics Options:
+<SelectSlideTextureQuality>
+<SelectSlideCoverSize>
+<SelectSlideFullScreen>
+<SelectSlideStretch>
+<SelectSlideVSync>
+
 ++++++++++
 Version 2:
 Rename <SelectSlideLyricsOnTop> to <SelectSlideLyricsPosition>
+
 ++++++++++
 Version 1:
 

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptions.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptions.xml
@@ -45,7 +45,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -80,7 +80,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -115,7 +115,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -150,7 +150,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -185,7 +185,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -220,7 +220,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -255,7 +255,7 @@
         <Y>18</Y>
         <Z>0</Z>
         <H>40.5</H>
-        <MaxW>213</MaxW>
+        <MaxW>200</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
         <Align>Center</Align>
@@ -277,7 +277,7 @@
       <Skin>Button</Skin>
       <SkinSelected>Button</SkinSelected>
       <Rect>
-        <X>1657.5</X>
+        <X>1668</X>
         <Y>820</Y>
         <W>150</W>
         <H>50</H>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
@@ -174,7 +174,7 @@
       <ResizeAlign>Center</ResizeAlign>
       <Style>Bold</Style>
       <Font>Outline</Font>
-      <Text>TR_SCREENOGRAPHICS_WARNINGRESTART</Text>
+      <Text>TR_SCREENO_WARNINGRESTART</Text>
       </Text>
   </Texts>
   <Buttons>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
@@ -40,7 +40,7 @@
       <Skin>Warning</Skin>
       <Color Name="StaticWarningColor" />
       <Rect>
-        <X>390</X>
+        <X>710</X>
         <Y>900</Y>
         <W>1140</W>
         <H>75</H>
@@ -163,7 +163,7 @@
       <Text>TR_SCREENOGRAPHICS_STRETCH</Text>
     </Text>
     <Text Name="TextWarningRestart">
-      <X>960</X>
+      <X>1280</X>
       <Y>920</Y>
       <Z>-1.1</Z>
       <H>37.5</H>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
@@ -301,7 +301,7 @@
       <TextStyle>Bold</TextStyle>
       <NumVisible>2</NumVisible>
     </SelectSlide>
-    <SelectSlide Name=" SelectSlideTextureQuality">
+    <SelectSlide Name="SelectSlideTextureQuality">
       <Skin />
       <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
       <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
@@ -14,7 +14,7 @@
     </Background>
   </Backgrounds>
   <Statics>
-    <Static Name="StaticMenuBar">
+    <Static Name="StaticMenuBarLyrics">
       <Skin />
       <Color Name="BackgroundColorAlpha" />
       <Rect>
@@ -25,9 +25,31 @@
         <Z>1</Z>
       </Rect>
     </Static>
+    <Static Name="StaticMenuBarGraphics">
+      <Skin />
+      <Color Name="BackgroundColorAlpha" />
+      <Rect>
+        <X>0</X>
+        <Y>430.5</Y>
+        <W>1920</W>
+        <H>67.5</H>
+        <Z>1</Z>
+      </Rect>
+    </Static>
+    <Static Name="StaticWarningRestart">
+      <Skin>Warning</Skin>
+      <Color Name="StaticWarningColor" />
+      <Rect>
+        <X>390</X>
+        <Y>900</Y>
+        <W>1140</W>
+        <H>75</H>
+        <Z>-1</Z>
+      </Rect>
+    </Static>
   </Statics>
   <Texts>
-    <Text Name="TextTitle">
+    <Text Name="TextTitleLyrics">
       <X>960</X>
       <Y>75</Y>
       <Z>0</Z>
@@ -41,6 +63,7 @@
       <Font>Outline</Font>
       <Text>TR_SCREENOLYRICS_OPTIONS</Text>
     </Text>
+    
     <Text Name="TextLyricsStyle">
       <X>112.5</X>
       <Y>160.5</Y>
@@ -69,6 +92,90 @@
       <Font>Outline</Font>
       <Text>TR_SCREENOLYRICS_POSITION</Text>
     </Text>
+    <Text Name="TextTitle">
+      <X>960</X>
+      <Y>445.5</Y>
+      <Z>0</Z>
+      <H>40.5</H>
+      <MaxW>0</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_OPTIONS</Text>
+    </Text>
+    <Text Name="TextTextureQuality">
+      <X>112.5</X>
+      <Y>520.5</Y>
+      <Z>0</Z>
+      <H>40.5</H>
+      <MaxW>0</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_TEXTUREQUALITY</Text>
+    </Text>
+    <Text Name="TextCoverSize">
+      <X>112.5</X>
+      <Y>610.5</Y>
+      <Z>0</Z>
+      <H>40.5</H>
+      <MaxW>0</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_COVERSIZE</Text>
+    </Text>
+    <Text Name="TextFullScreen">
+      <X>112.5</X>
+      <Y>700.5</Y>
+      <Z>0</Z>
+      <H>40.5</H>
+      <MaxW>0</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_FULLSCREEN</Text>
+    </Text>
+    <Text Name="TextStretch">
+      <X>112.5</X>
+      <Y>790.5</Y>
+      <Z>0</Z>
+      <H>40.5</H>
+      <MaxW>0</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_STRETCH</Text>
+    </Text>
+    <Text Name="TextWarningRestart">
+      <X>960</X>
+      <Y>920</Y>
+      <Z>-1.1</Z>
+      <H>37.5</H>
+      <MaxW>960</MaxW>
+      <Color Name="TextWarningColor" />
+      <SelColor Name="TextWarningColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENOGRAPHICS_WARNINGRESTART</Text>
+      </Text>
   </Texts>
   <Buttons>
     <Button Name="ButtonExit">
@@ -176,6 +283,174 @@
       <RectArrowRight>
         <X>1755</X>
         <Y>247.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColorAlpha" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>40.5</TextH>
+      <TextRelativeX>75</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>300</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>2</NumVisible>
+    </SelectSlide>
+    <SelectSlide Name="SelectTextureQuality">
+      <Skin />
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>750</X>
+        <Y>510</Y>
+        <W>1072.5</W>
+        <H>75</H>
+        <Z>0</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>757.5</X>
+        <Y>517.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1755</X>
+        <Y>517.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColorAlpha" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>40.5</TextH>
+      <TextRelativeX>75</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>462</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>3</NumVisible>
+    </SelectSlide>
+    <SelectSlide Name="SelectSlideCoverSize">
+      <Skin />
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>750</X>
+        <Y>600</Y>
+        <W>1072.5</W>
+        <H>75</H>
+        <Z>0</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>757.5</X>
+        <Y>607.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1755</X>
+        <Y>607.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColorAlpha" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>40.5</TextH>
+      <TextRelativeX>75</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>300</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>4</NumVisible>
+    </SelectSlide>
+    <SelectSlide Name="SelectSlideFullScreen">
+      <Skin />
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>750</X>
+        <Y>690</Y>
+        <W>1072.5</W>
+        <H>75</H>
+        <Z>0</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>757.5</X>
+        <Y>697.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1755</X>
+        <Y>697.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColorAlpha" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>40.5</TextH>
+      <TextRelativeX>75</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>300</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>2</NumVisible>
+    </SelectSlide>
+    <SelectSlide Name="SelectSlideStretch">
+      <Skin />
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>750</X>
+        <Y>780</Y>
+        <W>1072.5</W>
+        <H>75</H>
+        <Z>0</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>757.5</X>
+        <Y>787.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>0</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1755</X>
+        <Y>787.5</Y>
         <W>60</W>
         <H>60</H>
         <Z>0</Z>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenOptionsLyrics.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenOptionsLyrics</ScreenName>
-    <ScreenVersion>2</ScreenVersion>
+    <ScreenVersion>3</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -301,7 +301,7 @@
       <TextStyle>Bold</TextStyle>
       <NumVisible>2</NumVisible>
     </SelectSlide>
-    <SelectSlide Name="SelectTextureQuality">
+    <SelectSlide Name=" SelectSlideTextureQuality">
       <Skin />
       <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
       <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>

--- a/Vocaluxe/Base/CConfig.cs
+++ b/Vocaluxe/Base/CConfig.cs
@@ -452,7 +452,7 @@ namespace Vocaluxe.Base
                 case "TextureQuality":
                     return "TextureQuality: " + CHelper.ListStrings(Enum.GetNames(typeof(ETextureQuality)));
                 case "CoverSize":
-                    return "CoverSize (pixels): 32, 64, 128, 256, 512, 1024 (default: 128)";
+                    return "CoverSize (pixels): 32, 64, 128, 256, 512, 1024 (default: 512)";
                 case "NumScreens":
                     return "Number of screens to use. 1 - 6 (default: 1)";
                 case "ScreenW":

--- a/Vocaluxe/Program.cs
+++ b/Vocaluxe/Program.cs
@@ -90,6 +90,18 @@ namespace Vocaluxe
                 // Create data folder
                 Directory.CreateDirectory(CSettings.DataFolder);
 
+                // Delete CoverDB.sqlite if marker exists (cover size changed)
+                string flagPath = Path.Combine(CSettings.DataFolder, "DeleteCoverDB.flag");
+                string coverDbPath = Path.Combine(CSettings.DataFolder, CSettings.FileNameCoverDB);
+
+                if (File.Exists(flagPath))
+                {
+                    if (File.Exists(coverDbPath))
+                        File.Delete(coverDbPath); // Delete the database
+
+                    File.Delete(flagPath); // Remove the marker so it doesn't repeat
+                }
+
                 // Init Log
                 CLog.Init(CSettings.FolderNameLogs,
                     CSettings.FileNameMainLog, 

--- a/Vocaluxe/Screens/CScreenOptions.cs
+++ b/Vocaluxe/Screens/CScreenOptions.cs
@@ -27,7 +27,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 2; }
+            get { return 3; }
         }
            
         private const string _ButtonOptionsBack = "ButtonOptionsBack";  

--- a/Vocaluxe/Screens/CScreenOptionsLyrics.cs
+++ b/Vocaluxe/Screens/CScreenOptionsLyrics.cs
@@ -15,6 +15,7 @@
 // along with Vocaluxe. If not, see <http://www.gnu.org/licenses/>.
 #endregion
 
+using System;
 using System.Windows.Forms;
 using System.IO;
 using Vocaluxe.Base;
@@ -164,7 +165,6 @@ namespace Vocaluxe.Screens
                         
             CConfig.Config.Graphics.FullScreen = (EOffOn)_SelectSlides[_SelectSlideFullScreen].Selection;
             CConfig.Config.Graphics.Stretch = (EOffOn)_SelectSlides[_SelectSlideStretch].Selection;
-            CConfig.Config.Graphics.VSync = (EOffOn)_SelectSlides[_SelectSlideVSync].Selection;
             
             CConfig.SaveConfig();
         }

--- a/Vocaluxe/Screens/CScreenOptionsLyrics.cs
+++ b/Vocaluxe/Screens/CScreenOptionsLyrics.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -39,8 +39,9 @@ namespace Vocaluxe.Screens
         private const string _SelectSlideFullScreen = "SelectSlideFullScreen";
         private const string _SelectSlideStretch = "SelectSlideStretch";
         private const string _TextWarningRestart = "TextWarningRestart";
-
+        private const string _StaticWarningRestart = "StaticWarningRestart";
         private const string _ButtonExit = "ButtonExit";
+        private static readonly string[] CoverSizes = { "32", "64", "128", "256", "512", "1024" };
 
         public override void Init()
         {
@@ -49,6 +50,7 @@ namespace Vocaluxe.Screens
             _ThemeButtons = new string[] {_ButtonExit};
             _ThemeSelectSlides = new string[] {_SelectSlideLyricStyle, _SelectSlideLyricsPosition, _SelectSlideTextureQuality, _SelectSlideCoverSize, _SelectSlideFullScreen, _SelectSlideStretch};
             _ThemeTexts = new string[] {_TextWarningRestart};
+            _ThemeStatics = new string[] {_StaticWarningRestart};
         }
 
         public override void LoadTheme(string xmlPath)
@@ -59,10 +61,9 @@ namespace Vocaluxe.Screens
 
             _SelectSlides[_SelectSlideTextureQuality].SetValues<ETextureQuality>((int)CConfig.Config.Graphics.TextureQuality);
             
-            _SelectSlides[_SelectSlideCoverSize].AddValues(new string[] { "32", "64", "128", "256", "512", "1024" });
+            _SelectSlides[_SelectSlideCoverSize].AddValues(CoverSizes);
             int currentCoverSize = CConfig.Config.Graphics.CoverSize;
-            string[] options = { "32", "64", "128", "256", "512", "1024" };
-            int index = Array.IndexOf(options, currentCoverSize.ToString());
+            int index = Array.IndexOf(CoverSizes, currentCoverSize.ToString());
             _SelectSlides[_SelectSlideCoverSize].Selection = index;
             
             _SelectSlides[_SelectSlideFullScreen].SetValues<EOffOn>((int)CConfig.Config.Graphics.FullScreen);
@@ -71,7 +72,8 @@ namespace Vocaluxe.Screens
             _SelectSlides[_SelectSlideStretch].SetValues<EOffOn>((int)CConfig.Config.Graphics.Stretch);
             _SelectSlides[_SelectSlideStretch].Selection = (int)CConfig.Config.Graphics.Stretch;
 
-            _Texts[_TextWarningRestart].Visible = true;
+            _Texts[_TextWarningRestart].Visible = false;
+            _Statics[_StaticWarningRestart].Visible = false;
         }
 
         public override bool HandleInput(SKeyEvent keyEvent)
@@ -143,19 +145,30 @@ namespace Vocaluxe.Screens
             CConfig.Config.Game.LyricsPosition = (ELyricsPosition)_SelectSlides[_SelectSlideLyricsPosition].Selection;
             CConfig.Config.Theme.LyricStyle = (ELyricStyle)_SelectSlides[_SelectSlideLyricStyle].Selection;
 
-            CConfig.Config.Graphics.TextureQuality = (ETextureQuality)_SelectSlides[_SelectSlideTextureQuality].Selection;
-            
-            string[] options = { "32", "64", "128", "256", "512", "1024" };
-            string selectedValue = options[_SelectSlides[_SelectSlideCoverSize].Selection];
-            
-            // Detect cover size change
+            // Detect Texture quality change
+            ETextureQuality _currentTextureQuality = CConfig.Config.Graphics.TextureQuality;
+            ETextureQuality _newTextureQuality = (ETextureQuality)_SelectSlides[_SelectSlideTextureQuality].Selection;
+            if (_currentTextureQuality != _newTextureQuality)
+            {
+                _Texts[_TextWarningRestart].Visible = true;
+                _Statics[_StaticWarningRestart].Visible = true;    
+                CConfig.Config.Graphics.TextureQuality = _newTextureQuality;
+            }
+            else
+            {
+                CConfig.Config.Graphics.TextureQuality = _newTextureQuality;
+            }           
+
+            // Detect Cover size change
+            string selectedValue = CoverSizes[_SelectSlides[_SelectSlideCoverSize].Selection];
             int currentCoverSize = CConfig.Config.Graphics.CoverSize;
             int newCoverSize = int.Parse(selectedValue);
             if (currentCoverSize != newCoverSize)
             {
                 string flagPath = Path.Combine(CSettings.DataFolder, "DeleteCoverDB.flag");
                 File.Create(flagPath).Dispose();
-    
+                _Texts[_TextWarningRestart].Visible = true;
+               _Statics[_StaticWarningRestart].Visible = true;    
                 CConfig.Config.Graphics.CoverSize = newCoverSize;
             }
             else

--- a/Vocaluxe/Screens/CScreenOptionsLyrics.cs
+++ b/Vocaluxe/Screens/CScreenOptionsLyrics.cs
@@ -27,11 +27,16 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 2; }
+            get { return 3; }
         }
 
         private const string _SelectSlideLyricStyle = "SelectSlideLyricStyle";
         private const string _SelectSlideLyricsPosition = "SelectSlideLyricsPosition";
+        private const string _SelectSlideTextureQuality = "SelectSlideTextureQuality";
+        private const string _SelectSlideCoverSize = "SelectSlideCoverSize";
+        private const string _SelectSlideFullScreen = "SelectSlideFullScreen";
+        private const string _SelectSlideStretch = "SelectSlideStretch";
+        private const string _TextWarningRestart = "TextWarningRestart";
 
         private const string _ButtonExit = "ButtonExit";
 
@@ -40,7 +45,8 @@ namespace Vocaluxe.Screens
             base.Init();
 
             _ThemeButtons = new string[] {_ButtonExit};
-            _ThemeSelectSlides = new string[] {_SelectSlideLyricStyle, _SelectSlideLyricsPosition};
+            _ThemeSelectSlides = new string[] {_SelectSlideLyricStyle, _SelectSlideLyricsPosition, _SelectSlideTextureQuality, _SelectSlideCoverSize, _SelectSlideFullScreen, _SelectSlideStretch};
+            _ThemeTexts = new string[] {_TextWarningRestart};
         }
 
         public override void LoadTheme(string xmlPath)
@@ -48,6 +54,25 @@ namespace Vocaluxe.Screens
             base.LoadTheme(xmlPath);
             _SelectSlides[_SelectSlideLyricStyle].SetValues<ELyricStyle>((int)CConfig.Config.Theme.LyricStyle);
             _SelectSlides[_SelectSlideLyricsPosition].SetValues<ELyricsPosition>((int)CConfig.Config.Game.LyricsPosition);
+
+            _SelectSlides[_SelectSlideTextureQuality].SetValues<ETextureQuality>((int)CConfig.Config.Graphics.TextureQuality);
+            
+            _SelectSlides[_SelectSlideCoverSize].AddValues(new string[] { "32", "64", "128", "256", "512", "1024" });
+            int currentCoverSize = CConfig.Config.Graphics.CoverSize;
+            string[] options = { "32", "64", "128", "256", "512", "1024" };
+            int index = Array.IndexOf(options, currentCoverSize.ToString());
+            _SelectSlides[_SelectSlideCoverSize].Selection = index;
+            
+            _SelectSlides[_SelectSlideFullScreen].SetValues<EOffOn>((int)CConfig.Config.Graphics.FullScreen);
+            _SelectSlides[_SelectSlideFullScreen].Selection = (int)CConfig.Config.Graphics.FullScreen;
+
+            _SelectSlides[_SelectSlideStretch].SetValues<EOffOn>((int)CConfig.Config.Graphics.Stretch);
+            _SelectSlides[_SelectSlideStretch].Selection = (int)CConfig.Config.Graphics.Stretch;
+
+            _SelectSlides[_SelectSlideVSync].SetValues<EOffOn>((int)CConfig.Config.Graphics.VSync);
+            _SelectSlides[_SelectSlideVSync].Selection = (int)CConfig.Config.Graphics.VSync;
+
+            _Texts[_TextWarningRestart].Visible = true;
         }
 
         public override bool HandleInput(SKeyEvent keyEvent)
@@ -118,6 +143,31 @@ namespace Vocaluxe.Screens
         {
             CConfig.Config.Game.LyricsPosition = (ELyricsPosition)_SelectSlides[_SelectSlideLyricsPosition].Selection;
             CConfig.Config.Theme.LyricStyle = (ELyricStyle)_SelectSlides[_SelectSlideLyricStyle].Selection;
+
+            CConfig.Config.Graphics.TextureQuality = (ETextureQuality)_SelectSlides[_SelectSlideTextureQuality].Selection;
+            
+            string[] options = { "32", "64", "128", "256", "512", "1024" };
+            string selectedValue = options[_SelectSlides[_SelectSlideCoverSize].Selection];
+            
+            // Detect cover size change
+            int currentCoverSize = CConfig.Config.Graphics.CoverSize;
+            int newCoverSize = int.Parse(selectedValue);
+            if (currentCoverSize != newCoverSize)
+            {
+                string flagPath = Path.Combine(CSettings.DataFolder, "DeleteCoverDB.flag");
+                File.Create(flagPath).Dispose();
+    
+                CConfig.Config.Graphics.CoverSize = newCoverSize;
+            }
+            else
+            {
+                CConfig.Config.Graphics.CoverSize = newCoverSize;
+            }        
+                        
+            CConfig.Config.Graphics.FullScreen = (EOffOn)_SelectSlides[_SelectSlideFullScreen].Selection;
+            CConfig.Config.Graphics.Stretch = (EOffOn)_SelectSlides[_SelectSlideStretch].Selection;
+            CConfig.Config.Graphics.VSync = (EOffOn)_SelectSlides[_SelectSlideVSync].Selection;
+            
             CConfig.SaveConfig();
         }
     }

--- a/Vocaluxe/Screens/CScreenOptionsLyrics.cs
+++ b/Vocaluxe/Screens/CScreenOptionsLyrics.cs
@@ -16,6 +16,7 @@
 #endregion
 
 using System.Windows.Forms;
+using System.IO;
 using Vocaluxe.Base;
 using VocaluxeLib;
 using VocaluxeLib.Menu;
@@ -68,9 +69,6 @@ namespace Vocaluxe.Screens
 
             _SelectSlides[_SelectSlideStretch].SetValues<EOffOn>((int)CConfig.Config.Graphics.Stretch);
             _SelectSlides[_SelectSlideStretch].Selection = (int)CConfig.Config.Graphics.Stretch;
-
-            _SelectSlides[_SelectSlideVSync].SetValues<EOffOn>((int)CConfig.Config.Graphics.VSync);
-            _SelectSlides[_SelectSlideVSync].Selection = (int)CConfig.Config.Graphics.VSync;
 
             _Texts[_TextWarningRestart].Visible = true;
         }


### PR DESCRIPTION
This introduces the following Graphics Options to the Options screen, which were previously only accessible via the configuration file:
Texture Quality
Cover Size
Fullscreen
Stretched

Due to limited space in the current Options screen, these settings have been added to the Lyrics Options, which have now been renamed to “Lyrics/Graphics.” 
In the future, these graphics options can easily be moved to a dedicated screen during the redesign of the Options screen (see  #682).