### PR TITLE
Gameplay support for #VOCALS

### DIFF
--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -22,6 +22,7 @@
   <string name="TR_GAMEMODE_SHORTSONG">Short version</string>
   <string name="TR_AUDIOMODE_NORMAL">Normal</string>
   <string name="TR_AUDIOMODE_INSTRUMENTAL">Instrumental</string>
+  <string name="TR_AUDIOMODE_VOCALS">Instrumental/Vocals</string>
   <string name="TR_AUDIOMODE_KARAOKE">Karaoke</string>
   <string name="TR_RATING_KARAOKE">Karaoke</string>
   <string name="TR_RATING_VOCAL_HERO">Vocal Hero</string>
@@ -171,6 +172,7 @@
   <string name="TR_SCREENSING_BUTTON_SKIP">Skip this song</string>
   <string name="TR_SCREENSING_BUTTON_RESTART_ROUND">Restart round</string>
   <string name="TR_SCREENSING_BUTTON_RESTART_GAME">Restart game</string>
+  <string name="TR_SCREENSING_VOCALSVOLUME">Vocals track volume</string>
   <string name="TR_SCREENSING_NOMORESONGS">No more songs in playlist!</string>
   <string name="TR_SCREENSING_NOWEBCAM">No webcam available!</string>
   <string name="TR_SCREENSING_ASPECTRATIO">Aspect Ratio: %a</string>

--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -149,6 +149,10 @@
   <string name="TR_SCREENSONG_BUTTON_STARTMEDLEY">Sing medley-songs</string>
   <string name="TR_SCREENSONG_NEWPLAYLIST">New playlist</string>
   <string name="TR_SCREENSONG_SONGOPTIONS">Song Options</string>
+  <string name="TR_SCREENSONG_LENGTH">Song length</string>
+  <string name="TR_SCREENSONG_AUDIOMODE">Audio mode</string>
+  <string name="TR_SCREENSONG_PLAYLIST">Playlist</string>
+  <string name="TR_SCREENSONG_PLAYERSELECT">Player selection</string>
   <string name="TR_SCREENSONG_PLAYERSELECT_ON">Show player selection</string>
   <string name="TR_SCREENSONG_PLAYERSELECT_OFF">Skip player selection</string>  
   <string name="TR_SCREENSONG_SEARCH">Search:</string>

--- a/Output/Themes/Changelog/Changelog_ScreenSing.txt
+++ b/Output/Themes/Changelog/Changelog_ScreenSing.txt
@@ -1,5 +1,12 @@
 ScreenSing
 +++++++++
+Version 13
+
+Add:
+<SelectSlidePauseVocalsVolume>
+<TextPauseVocalsVolume>
+
++++++++++
 Version 12
 
 Add:

--- a/Output/Themes/Changelog/Changelog_ScreenSong.txt
+++ b/Output/Themes/Changelog/Changelog_ScreenSong.txt
@@ -1,6 +1,18 @@
 ScreenSong
 
 ++++++++++
+Version 13:
+
+Headers for Song Options
+
+Add:
+<TextOptionsTitle>
+<TextOptionsLenght>
+<TextOptionsAudioMode> 
+<TextOptionsPlayerSelect> 
+<TextOptionsPlaylist> 
+
+++++++++++
 Version 12:
 
 Add:

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSing.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSing.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenSing</ScreenName>
-    <ScreenVersion>11</ScreenVersion>
+    <ScreenVersion>13</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -707,6 +707,20 @@
       <Style>Bold</Style>
       <Font>Normal</Font>
       <Text />
+    </Text>
+    <Text Name="TextPauseVocalsVolume">
+      <X>112.5</X>
+      <Y>823</Y>
+      <Z>-2.11</Z>
+      <H>40.5</H>
+      <MaxW>600</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Left</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSING_VOCALSVOLUME</Text>
     </Text>
     <Text Name="TextDuetName1">
       <X>15</X>
@@ -1582,7 +1596,50 @@
       <ProcessedColor Name="LyricProcessedColor" />
     </Lyric>
   </Lyrics>
-  <SelectSlides />
+  <SelectSlides>
+    <SelectSlide Name="SelectSlidePauseVocalsVolume">
+      <Skin />
+      <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
+      <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
+      <SkinSelected>SelectSlide</SkinSelected>
+      <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
+      <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
+      <Rect>
+        <X>750</X>
+        <Y>808</Y>
+        <W>1072.5</W>
+        <H>75</H>
+        <Z>-2.11</Z>
+      </Rect>
+      <RectArrowLeft>
+        <X>757.5</X>
+        <Y>812.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>-2.11</Z>
+      </RectArrowLeft>
+      <RectArrowRight>
+        <X>1755</X>
+        <Y>812.5</Y>
+        <W>60</W>
+        <H>60</H>
+        <Z>-2.11</Z>
+      </RectArrowRight>
+      <Color Name="SelectSlideColor" />
+      <SelColor Name="SelectSlideSelColor" />
+      <ArrowColor Name="ArrowColor" />
+      <ArrowSelColor Name="ArrowSelColor" />
+      <TextColor Name="TextColorAlpha" />
+      <TextSelColor Name="TextSelColor" />
+      <TextH>40.5</TextH>
+      <TextRelativeX>75</TextRelativeX>
+      <TextRelativeY>0</TextRelativeY>
+      <TextMaxW>300</TextMaxW>
+      <TextFont>Outline</TextFont>
+      <TextStyle>Bold</TextStyle>
+      <NumVisible>3</NumVisible>
+    </SelectSlide>
+  </SelectSlides>
   <SingNotes>
     <SingBar Name="SingBars">
       <SkinLeft>NoteLeft</SkinLeft>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSing.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSing.xml
@@ -709,11 +709,11 @@
       <Text />
     </Text>
     <Text Name="TextPauseVocalsVolume">
-      <X>112.5</X>
-      <Y>823</Y>
+      <X>217.5</X>
+      <Y>818</Y>
       <Z>-2.11</Z>
       <H>40.5</H>
-      <MaxW>600</MaxW>
+      <MaxW>520</MaxW>
       <Color Name="TextColor" />
       <SelColor Name="TextSelColor" />
       <Align>Left</Align>
@@ -1605,24 +1605,24 @@
       <SkinArrowLeftSelected>SelectSlideArrowLeft</SkinArrowLeftSelected>
       <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
       <Rect>
-        <X>750</X>
-        <Y>808</Y>
-        <W>1072.5</W>
-        <H>75</H>
+        <X>752</X>
+        <Y>820</Y>
+        <W>958</W>
+        <H>40</H>
         <Z>-2.11</Z>
       </Rect>
       <RectArrowLeft>
         <X>757.5</X>
-        <Y>812.5</Y>
-        <W>60</W>
-        <H>60</H>
+        <Y>822.5</Y>
+        <W>35</W>
+        <H>35</H>
         <Z>-2.11</Z>
       </RectArrowLeft>
       <RectArrowRight>
-        <X>1755</X>
-        <Y>812.5</Y>
-        <W>60</W>
-        <H>60</H>
+        <X>1667.5</X>
+        <Y>822.5</Y>
+        <W>35</W>
+        <H>35</H>
         <Z>-2.11</Z>
       </RectArrowRight>
       <Color Name="SelectSlideColor" />
@@ -1637,7 +1637,7 @@
       <TextMaxW>300</TextMaxW>
       <TextFont>Outline</TextFont>
       <TextStyle>Bold</TextStyle>
-      <NumVisible>3</NumVisible>
+      <NumVisible>5</NumVisible>
     </SelectSlide>
   </SelectSlides>
   <SingNotes>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -2,7 +2,7 @@
 <Screen xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <Informations>
     <ScreenName>ScreenSong</ScreenName>
-    <ScreenVersion>12</ScreenVersion>
+    <ScreenVersion>13</ScreenVersion>
   </Informations>
   <Backgrounds>
     <Background Name="Background1">
@@ -93,7 +93,7 @@
       <SelColor Name="TextSelColor" />
       <Align>Center</Align>
       <ResizeAlign>Center</ResizeAlign>
-      <Style>Normal</Style>
+      <Style>Bold</Style>
       <Font>Outline</Font>
       <Text>TR_SCREENSONG_SORTING</Text>
     </Text>
@@ -253,7 +253,7 @@
       <X>330</X>
       <Y>60</Y>
       <Z>-2.11</Z>
-      <H>45</H>
+      <H>40</H>
       <MaxW>525</MaxW>
       <Color Name="TextColor" />
       <SelColor Name="TextSelColor" />
@@ -262,6 +262,62 @@
       <Style>Bold</Style>
       <Font>Outline</Font>
       <Text>TR_SCREENSONG_SONGOPTIONS</Text>
+    </Text>
+    <Text Name="TextOptionsLength">
+      <X>330</X>
+      <Y>155</Y>
+      <Z>-2.11</Z>
+      <H>30</H>
+      <MaxW>525</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_LENGTH</Text>
+    </Text>
+    <Text Name="TextOptionsAudioMode">
+      <X>330</X>
+      <Y>230</Y>
+      <Z>-2.11</Z>
+      <H>30</H>
+      <MaxW>525</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_AUDIOMODE</Text>
+    </Text>
+    <Text Name="TextOptionsPlayerSelect">
+      <X>330</X>
+      <Y>305</Y>
+      <Z>-2.11</Z>
+      <H>30</H>
+      <MaxW>525</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_PLAYERSELECT</Text>
+    </Text>
+    <Text Name="TextOptionsPlaylist">
+      <X>330</X>
+      <Y>380</Y>
+      <Z>-2.11</Z>
+      <H>30</H>
+      <MaxW>525</MaxW>
+      <Color Name="TextColor" />
+      <SelColor Name="TextSelColor" />
+      <Align>Center</Align>
+      <ResizeAlign>Center</ResizeAlign>
+      <Style>Bold</Style>
+      <Font>Outline</Font>
+      <Text>TR_SCREENSONG_PLAYLIST</Text>
     </Text>
     <Text Name="TextHelpBar">
       <X>60</X>
@@ -486,16 +542,16 @@
       <SkinSelected>SongSelectButton</SkinSelected>
       <Rect>
         <X>60</X>
-        <Y>546</Y>
+        <Y>554</Y>
         <W>540</W>
-        <H>53</H>
+        <H>45</H>
         <Z>-2.11</Z>
       </Rect>
       <Color Name="ButtonColor" />
       <SelColor Name="ButtonSelColor" />
       <Text Name="Text">
         <X>270</X>
-        <Y>10.5</Y>
+        <Y>2</Y>
         <Z>0</Z>
         <H>37.5</H>
         <MaxW>525</MaxW>
@@ -513,18 +569,18 @@
       <SkinSelected>SongSelectButton</SkinSelected>
       <Rect>
         <X>60</X>
-        <Y>415</Y>
+        <Y>451</Y>
         <W>540</W>
-        <H>53</H>
+        <H>35</H>
         <Z>-2.11</Z>
       </Rect>
       <Color Name="ButtonColor" />
       <SelColor Name="ButtonSelColor" />
       <Text Name="Text">
         <X>270</X>
-        <Y>10.5</Y>
+        <Y>2</Y>
         <Z>0</Z>
-        <H>37.5</H>
+        <H>35</H>
         <MaxW>525</MaxW>
         <Color Name="ButtonTextColor" />
         <SelColor Name="ButtonTextSelColor" />
@@ -542,14 +598,14 @@
         <X>60</X>
         <Y>104</Y>
         <W>540</W>
-        <H>57</H>
+        <H>45</H>
         <Z>-2.11</Z>
       </Rect>
       <Color Name="ButtonColor" />
       <SelColor Name="ButtonSelColor" />
       <Text Name="Text">
         <X>270</X>
-        <Y>10.5</Y>
+        <Y>3</Y>
         <Z>0</Z>
         <H>37.5</H>
         <MaxW>525</MaxW>
@@ -813,21 +869,21 @@
         <Text>TR_SCREENSONG_BUTTON_STARTMEDLEY</Text>
       </Text>
     </Button>
-    <Button Name="ButtonOptionsHighscore">
+   <Button Name="ButtonOptionsHighscore">
       <Skin>SongSelectButton</Skin>
       <SkinSelected>SongSelectButton</SkinSelected>
       <Rect>
         <X>60</X>
-        <Y>486.5</Y>
+        <Y>497.5</Y>
         <W>540</W>
-        <H>53</H>
+        <H>45</H>
         <Z>-2.11</Z>
       </Rect>
       <Color Name="ButtonColor" />
       <SelColor Name="ButtonSelColor" />
       <Text Name="Text">
         <X>270</X>
-        <Y>10.5</Y>
+        <Y>2</Y>
         <Z>0</Z>
         <H>37.5</H>
         <MaxW>525</MaxW>
@@ -907,7 +963,7 @@
         </TextTitle>
         <TextSongLength Name="TextSongLength">
           <X>586.5</X>
-          <Y>735</Y>
+          <Y>743</Y>
           <Z>-11</Z>
           <H>42</H>
           <MaxW>150</MaxW>
@@ -1167,7 +1223,7 @@
   </SongMenus>
   <Lyrics />
   <SelectSlides>
-    <SelectSlide Name="SelectSlideOptionsMode">
+   <SelectSlide Name="SelectSlideOptionsMode">
       <Skin>SongSelectButton</Skin>
       <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
       <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>
@@ -1176,23 +1232,23 @@
       <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
       <Rect>
         <X>60</X>
-        <Y>167.5</Y>
+        <Y>186</Y>
         <W>540</W>
-        <H>53</H>
+        <H>35</H>
         <Z>-2.11</Z>
       </Rect>
       <RectArrowLeft>
         <X>67.5</X>
-        <Y>172.5</Y>
-        <W>45</W>
-        <H>45</H>
+        <Y>188,5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowLeft>
       <RectArrowRight>
-        <X>547.5</X>
-        <Y>172.5</Y>
-        <W>45</W>
-        <H>45</H>
+        <X>560</X>
+        <Y>188,5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowRight>
       <Color Name="ButtonColor" />
@@ -1201,7 +1257,7 @@
       <ArrowSelColor Name="ArrowSelColor" />
       <TextColor Name="TextColorAlpha" />
       <TextSelColor Name="TextColorAlpha" />
-      <TextH>37.5</TextH>
+      <TextH>35</TextH>
       <TextRelativeX>75</TextRelativeX>
       <TextRelativeY>0</TextRelativeY>
       <TextMaxW>420</TextMaxW>
@@ -1218,23 +1274,23 @@
       <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
       <Rect>
         <X>60</X>
-        <Y>286</Y>
+        <Y>336</Y>
         <W>540</W>
-        <H>53</H>
+        <H>35</H>
         <Z>-2.11</Z>
       </Rect>
       <RectArrowLeft>
         <X>67.5</X>
-        <Y>291</Y>
-        <W>45</W>
-        <H>45</H>
+        <Y>338.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowLeft>
       <RectArrowRight>
-        <X>547.5</X>
-        <Y>291</Y>
-        <W>45</W>
-        <H>45</H>
+        <X>560</X>
+        <Y>338.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowRight>
       <Color Name="ButtonColor" />
@@ -1243,7 +1299,7 @@
       <ArrowSelColor Name="ArrowSelColor" />
       <TextColor Name="TextColorAlpha" />
       <TextSelColor Name="TextColorAlpha" />
-      <TextH>37.5</TextH>
+      <TextH>35</TextH>
       <TextRelativeX>175</TextRelativeX>
       <TextRelativeY>0</TextRelativeY>
       <TextMaxW>420</TextMaxW>
@@ -1260,23 +1316,23 @@
       <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
       <Rect>
         <X>60</X>
-        <Y>227</Y>
+        <Y>261</Y>
         <W>540</W>
-        <H>53</H>
+        <H>35</H>
         <Z>-2.11</Z>
       </Rect>
       <RectArrowLeft>
         <X>67.5</X>
-        <Y>232</Y>
-        <W>45</W>
-        <H>45</H>
+        <Y>263.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowLeft>
       <RectArrowRight>
-        <X>547.5</X>
-        <Y>232</Y>
-        <W>45</W>
-        <H>45</H>
+        <X>560</X>
+        <Y>263.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowRight>
       <Color Name="ButtonColor" />
@@ -1285,7 +1341,7 @@
       <ArrowSelColor Name="ArrowSelColor" />
       <TextColor Name="TextColorAlpha" />
       <TextSelColor Name="TextColorAlpha" />
-      <TextH>37.5</TextH>
+      <TextH>35</TextH>
       <TextRelativeX>75</TextRelativeX>
       <TextRelativeY>0</TextRelativeY>
       <TextMaxW>420</TextMaxW>
@@ -1302,23 +1358,23 @@
       <SkinArrowRightSelected>SelectSlideArrowRight</SkinArrowRightSelected>
       <Rect>
         <X>60</X>
-        <Y>355.5</Y>
+        <Y>411</Y>
         <W>540</W>
-        <H>53</H>
+        <H>35</H>
         <Z>-2.11</Z>
       </Rect>
       <RectArrowLeft>
         <X>67.5</X>
-        <Y>360.5</Y>
-        <W>45</W>
-        <H>45</H>
+        <Y>413.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowLeft>
       <RectArrowRight>
-        <X>547.5</X>
-        <Y>360.5</Y>
-        <W>45</W>
-        <H>45</H>
+        <X>560</X>
+        <Y>413.5</Y>
+        <W>30</W>
+        <H>30</H>
         <Z>-2.12</Z>
       </RectArrowRight>
       <Color Name="ButtonColor" />
@@ -1327,7 +1383,7 @@
       <ArrowSelColor Name="ArrowSelColor" />
       <TextColor Name="TextColorAlpha" />
       <TextSelColor Name="TextColorAlpha" />
-      <TextH>37.5</TextH>
+      <TextH>35</TextH>
       <TextRelativeX>75</TextRelativeX>
       <TextRelativeY>0</TextRelativeY>
       <TextMaxW>420</TextMaxW>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -869,7 +869,7 @@
         <Text>TR_SCREENSONG_BUTTON_STARTMEDLEY</Text>
       </Text>
     </Button>
-   <Button Name="ButtonOptionsHighscore">
+    <Button Name="ButtonOptionsHighscore">
       <Skin>SongSelectButton</Skin>
       <SkinSelected>SongSelectButton</SkinSelected>
       <Rect>
@@ -1223,7 +1223,7 @@
   </SongMenus>
   <Lyrics />
   <SelectSlides>
-   <SelectSlide Name="SelectSlideOptionsMode">
+    <SelectSlide Name="SelectSlideOptionsMode">
       <Skin>SongSelectButton</Skin>
       <SkinArrowLeft>SelectSlideArrowLeft</SkinArrowLeft>
       <SkinArrowRight>SelectSlideArrowRight</SkinArrowRight>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -93,7 +93,7 @@
       <SelColor Name="TextSelColor" />
       <Align>Center</Align>
       <ResizeAlign>Center</ResizeAlign>
-      <Style>Bold</Style>
+      <Style>Normal</Style>
       <Font>Outline</Font>
       <Text>TR_SCREENSONG_SORTING</Text>
     </Text>

--- a/Vocaluxe/Base/CConfig.cs
+++ b/Vocaluxe/Base/CConfig.cs
@@ -153,6 +153,8 @@ namespace Vocaluxe.Base
             public int GameMusicVolume;
             [XmlRanged(0, 100), DefaultValue(80)]
             public int SoundEffectVolume;
+            [XmlRanged(0, 100), DefaultValue(50)]
+            public int VocalsVolume;
             [DefaultValue(EOffOn.TR_CONFIG_OFF)]
             public EOffOn KaraokeEffect;
             [XmlRanged(0, 1), DefaultValue(1.0f)]
@@ -338,6 +340,16 @@ namespace Vocaluxe.Base
             }
         }
 
+        public static int VocalsVolume
+        {
+            get { return Config.Sound.VocalsVolume; }
+            set
+            {
+                Config.Sound.VocalsVolume = value.Clamp(0, 100);
+                SaveConfig();
+            }
+        }
+
         public static int PreviewMusicVolume
         {
             get { return Config.Sound.PreviewMusicVolume; }
@@ -511,6 +523,8 @@ namespace Vocaluxe.Base
                     return "Game Volume from 0 to 100";
                 case "SoundEffectVolume":
                     return "Sound Effect Volume from 0 to 100";
+                case "VocalsVolume":
+                    return "Vocals Volume from 0 to 100";
                 case "KaraokeEffect":
                     return "Apply a karaoke effect to song playback (EPlaybackLib.GstreamerSharp only)";
                 case "KaraokeEffectLevel":

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -380,15 +380,11 @@ namespace Vocaluxe.Screens
                             float newTime = _CurrentTime + (keyEvent.Mod == EModifier.Shift ? 10f : 30f);
                             if (CSound.GetLength(_CurrentStream) < newTime)
                                 newTime = CSound.GetLength(_CurrentStream) - 1f;
-                            
+                                CSound.SetPosition(_CurrentStream, newTime);
+                                
                             if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
                             {
-                                CSound.SetPosition(_CurrentStream, newTime);
                                 CSound.SetPosition(_CurrentStreamVocals, newTime);
-                            }
-                            else
-                            {
-                            CSound.SetPosition(_CurrentStream, newTime);
                             }
 
                             _ShowInfoText(CBase.Language.Translate("TR_SCREENSING_SKIPPEDSECONDS").Replace("%s", (keyEvent.Mod == EModifier.Shift ? "10" : "30")));

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -379,10 +379,8 @@ namespace Vocaluxe.Screens
 
                             float newTime = _CurrentTime + (keyEvent.Mod == EModifier.Shift ? 10f : 30f);
                             if (CSound.GetLength(_CurrentStream) < newTime)
-                            {
                                 newTime = CSound.GetLength(_CurrentStream) - 1f;
-                                CSound.SetPosition(_CurrentStream, newTime);
-                            }
+                            CSound.SetPosition(_CurrentStream, newTime);
                                 
                             if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
                             {

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -379,8 +379,10 @@ namespace Vocaluxe.Screens
 
                             float newTime = _CurrentTime + (keyEvent.Mod == EModifier.Shift ? 10f : 30f);
                             if (CSound.GetLength(_CurrentStream) < newTime)
+                            {
                                 newTime = CSound.GetLength(_CurrentStream) - 1f;
                                 CSound.SetPosition(_CurrentStream, newTime);
+                            }
                                 
                             if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
                             {

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -120,7 +120,7 @@ namespace Vocaluxe.Screens
 
         private int _CurrentBeat;
         private int _CurrentStream = -1;
-        private int _StreamVocals = -1;
+        private int _CurrentStreamVocals = -1;
         private float _Length = -1f;
 
         private CVideoStream _CurrentVideo;
@@ -384,7 +384,7 @@ namespace Vocaluxe.Screens
                             if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
                             {
                                 CSound.SetPosition(_CurrentStream, newTime);
-                                CSound.SetPosition(_StreamVocals, newTime);
+                                CSound.SetPosition(_CurrentStreamVocals, newTime);
                             }
                             else
                             {
@@ -1098,7 +1098,7 @@ namespace Vocaluxe.Screens
             
             if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
             {
-                CSound.Play(_StreamVocals);
+                CSound.Play(_CurrentStreamVocals);
             }
             
             CRecord.Start();
@@ -1232,19 +1232,19 @@ namespace Vocaluxe.Screens
                     // Store current position before pausing
                     _PausePosition = CSound.GetPosition(_CurrentStream);
                     CSound.Pause(_CurrentStream);
-                    CSound.Pause(_StreamVocals);
+                    CSound.Pause(_CurrentStreamVocals);
                 }
                 else
                 {
                     // Reset both streams to stored position to keep them in sync and update vocals volume
                     CConfig.VocalsVolume = _SelectSlides[_SelectSlidePauseVocalsVolume].Selection * 5;
                     CConfig.SaveConfig();
-                    CSound.SetStreamVolume(_StreamVocals, CConfig.VocalsVolume);
+                    CSound.SetStreamVolume(_CurrentStreamVocals, CConfig.VocalsVolume);
                     CSound.SetPosition(_CurrentStream, _PausePosition);
-                    CSound.SetPosition(_StreamVocals, _PausePosition);
+                    CSound.SetPosition(_CurrentStreamVocals, _PausePosition);
                     // Start both streams simultaneously
                     CSound.Play(_CurrentStream);
-                    CSound.Play(_StreamVocals);
+                    CSound.Play(_CurrentStreamVocals);
                 }
             }
             else
@@ -1294,9 +1294,9 @@ namespace Vocaluxe.Screens
             else if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
             {
                 _CurrentStream = CSound.Load(song.GetInstrumental(), false, true, EAudioEffect.None);
-                _StreamVocals = CSound.Load(song.GetVocals(), false, true, EAudioEffect.None);
-                CSound.SetStreamVolume(_StreamVocals, CConfig.VocalsVolume);
-                CSound.SetPosition(_StreamVocals, song.Start);
+                _CurrentStreamVocals = CSound.Load(song.GetVocals(), false, true, EAudioEffect.None);
+                CSound.SetStreamVolume(_CurrentStreamVocals, CConfig.VocalsVolume);
+                CSound.SetPosition(_CurrentStreamVocals, song.Start);
             }   
             else
             {
@@ -1410,9 +1410,9 @@ namespace Vocaluxe.Screens
             if (_CurrentStream > -1)
             {
                 CSound.FadeAndClose(_CurrentStream, 0, 0.5f);
-                CSound.FadeAndClose(_StreamVocals, 0, 0.5f);
+                CSound.FadeAndClose(_CurrentStreamVocals, 0, 0.5f);
                 _CurrentStream = -1;
-                _StreamVocals = -1;
+                _CurrentStreamVocals = -1;
             }
             CRecord.Stop();
             if (_CurrentVideo != null)

--- a/Vocaluxe/Screens/CScreenSing.cs
+++ b/Vocaluxe/Screens/CScreenSing.cs
@@ -41,7 +41,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 12; }
+            get { return 13; }
         }
 
         private struct STimeRect
@@ -58,6 +58,7 @@ namespace Vocaluxe.Screens
         private const string _TextDuetName2 = "TextDuetName2";
         private const string _TextMedleyCountdown = "TextMedleyCountdown";
         private const string _TextPauseSongName = "TextPauseSongName";
+        private const string _TextPauseVocalsVolume = "TextPauseVocalsVolume";
         private string[,,] _TextScores;
         private string[,,] _TextNames;
         private List<string> _TextsPause;
@@ -89,6 +90,9 @@ namespace Vocaluxe.Screens
         private const string _ButtonRestartGame = "ButtonRestartGame";
         private const string _ButtonSkip = "ButtonSkip";
 
+        private const string _SelectSlidePauseVocalsVolume = "SelectSlidePauseVocalsVolume";
+        private List<string> _SelectSlidesPause;
+
         private const string _LyricMain = "LyricMain";
         private const string _LyricSub = "LyricSub";
         private const string _LyricMainDuet = "LyricMainDuet";
@@ -116,6 +120,7 @@ namespace Vocaluxe.Screens
 
         private int _CurrentBeat;
         private int _CurrentStream = -1;
+        private int _StreamVocals = -1;
         private float _Length = -1f;
 
         private CVideoStream _CurrentVideo;
@@ -125,6 +130,8 @@ namespace Vocaluxe.Screens
 
         private float _CurrentTime;
         private float _FinishTime;
+        
+        private float _PausePosition;
 
         private float _TimeToFirstNote;
         private float _RemainingTimeToFirstNote;
@@ -193,6 +200,7 @@ namespace Vocaluxe.Screens
             _ThemeButtons = new string[] { _ButtonCancel, _ButtonContinue, _ButtonRestartGame, _ButtonRestartRound, _ButtonSkip };
             _ThemeLyrics = new string[] { _LyricMain, _LyricSub, _LyricMainDuet, _LyricSubDuet, _LyricMainTop, _LyricSubTop };
             _ThemeSingNotes = new string[] { _SingBars };
+            _ThemeSelectSlides = new string[] { _SelectSlidePauseVocalsVolume };
 
             _TimeRects = new List<STimeRect>();
             _TimerSongText = new Stopwatch();
@@ -225,6 +233,11 @@ namespace Vocaluxe.Screens
 
             _StaticsPause = new List<string>();
             _TextsPause = new List<string>();
+            _SelectSlidesPause = new List<string>();
+
+            _SelectSlides[_SelectSlidePauseVocalsVolume].AddValues(new string[]
+                {"0", "5", "10", "15", "20", "25", "30", "35", "40", "45", "50", "55", "60", "65", "70", "75", "80", "85", "90", "95", "100"});
+            _SelectSlides[_SelectSlidePauseVocalsVolume].Selection = CConfig.VocalsVolume / 5;
 
             //Automatically find statics and texts with pause prefix
             foreach (CStatic s in _Statics.Where(s => s.ThemeLoaded && s.GetThemeName().StartsWith("StaticPause")))
@@ -232,6 +245,9 @@ namespace Vocaluxe.Screens
 
             foreach (CText t in _Texts.Where(s => s.ThemeLoaded && s.GetThemeName().StartsWith("TextPause")))
                 _TextsPause.Add(t.GetThemeName());
+
+            foreach (CText t in _Texts.Where(s => s.ThemeLoaded && s.GetThemeName().StartsWith("SelectSlidePause")))
+                _SelectSlidesPause.Add(t.GetThemeName());
         }
 
         public override bool HandleInput(SKeyEvent keyEvent)
@@ -364,7 +380,16 @@ namespace Vocaluxe.Screens
                             float newTime = _CurrentTime + (keyEvent.Mod == EModifier.Shift ? 10f : 30f);
                             if (CSound.GetLength(_CurrentStream) < newTime)
                                 newTime = CSound.GetLength(_CurrentStream) - 1f;
+                            
+                            if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
+                            {
+                                CSound.SetPosition(_CurrentStream, newTime);
+                                CSound.SetPosition(_StreamVocals, newTime);
+                            }
+                            else
+                            {
                             CSound.SetPosition(_CurrentStream, newTime);
+                            }
 
                             _ShowInfoText(CBase.Language.Translate("TR_SCREENSING_SKIPPEDSECONDS").Replace("%s", (keyEvent.Mod == EModifier.Shift ? "10" : "30")));
                         }
@@ -1070,6 +1095,12 @@ namespace Vocaluxe.Screens
         {
             _PrepareTimeLine();
             CSound.Play(_CurrentStream);
+            
+            if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
+            {
+                CSound.Play(_StreamVocals);
+            }
+            
             CRecord.Start();
             if (_Webcam)
                 CWebcam.Start();
@@ -1175,11 +1206,17 @@ namespace Vocaluxe.Screens
             foreach (String s in _TextsPause)
                 _Texts[s].Visible = _Pause;
 
+            foreach (String s in _SelectSlidesPause)
+                _SelectSlides[s].Visible = _Pause;
+
             _Buttons[_ButtonCancel].Visible = _Pause;
             _Buttons[_ButtonContinue].Visible = _Pause;
             _Buttons[_ButtonSkip].Visible = _Pause && CGame.NumRounds > CGame.RoundNr && CGame.NumRounds > 1;
             _Buttons[_ButtonRestartGame].Visible = _Pause;
             _Buttons[_ButtonRestartRound].Visible = _Pause && CGame.NumRounds > 1;
+            
+            _SelectSlides[_SelectSlidePauseVocalsVolume].Visible = _Pause && (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS);
+            _Texts[_TextPauseVocalsVolume].Visible = _Pause && (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS);
 
             if (_Pause && _TimerSongText.IsRunning)            
                 _TimerSongText.Stop();
@@ -1188,10 +1225,35 @@ namespace Vocaluxe.Screens
 
             _Texts[_TextSongName].Visible = !_Pause;
 
-            if (_Pause)
-                CSound.Pause(_CurrentStream);
+            if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
+            {
+                if (_Pause)
+                {
+                    // Store current position before pausing
+                    _PausePosition = CSound.GetPosition(_CurrentStream);
+                    CSound.Pause(_CurrentStream);
+                    CSound.Pause(_StreamVocals);
+                }
+                else
+                {
+                    // Reset both streams to stored position to keep them in sync and update vocals volume
+                    CConfig.VocalsVolume = _SelectSlides[_SelectSlidePauseVocalsVolume].Selection * 5;
+                    CConfig.SaveConfig();
+                    CSound.SetStreamVolume(_StreamVocals, CConfig.VocalsVolume);
+                    CSound.SetPosition(_CurrentStream, _PausePosition);
+                    CSound.SetPosition(_StreamVocals, _PausePosition);
+                    // Start both streams simultaneously
+                    CSound.Play(_CurrentStream);
+                    CSound.Play(_StreamVocals);
+                }
+            }
             else
-                CSound.Play(_CurrentStream);
+            {
+                if (_Pause)
+                    CSound.Pause(_CurrentStream);
+                else
+                    CSound.Play(_CurrentStream);
+            }
         }
         #endregion
 
@@ -1229,6 +1291,13 @@ namespace Vocaluxe.Screens
             {
                 _CurrentStream = CSound.Load(song.GetInstrumental(), false, true, EAudioEffect.None);
             }
+            else if (CScreenSong.GetAudioMode() == EAudioMode.TR_AUDIOMODE_VOCALS)
+            {
+                _CurrentStream = CSound.Load(song.GetInstrumental(), false, true, EAudioEffect.None);
+                _StreamVocals = CSound.Load(song.GetVocals(), false, true, EAudioEffect.None);
+                CSound.SetStreamVolume(_StreamVocals, CConfig.VocalsVolume);
+                CSound.SetPosition(_StreamVocals, song.Start);
+            }   
             else
             {
                 _CurrentStream = CSound.Load(song.GetMP3(), false, true, CConfig.Config.Sound.KaraokeEffect == EOffOn.TR_CONFIG_ON ? EAudioEffect.Karaoke : EAudioEffect.None); 
@@ -1341,7 +1410,9 @@ namespace Vocaluxe.Screens
             if (_CurrentStream > -1)
             {
                 CSound.FadeAndClose(_CurrentStream, 0, 0.5f);
+                CSound.FadeAndClose(_StreamVocals, 0, 0.5f);
                 _CurrentStream = -1;
+                _StreamVocals = -1;
             }
             CRecord.Stop();
             if (_CurrentVideo != null)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1030,7 +1030,7 @@ namespace Vocaluxe.Screens
                 else
                     gm = CSongs.VisibleSongs[songNr].IsDuet ? EGameMode.TR_GAMEMODE_DUET : EGameMode.TR_GAMEMODE_NORMAL;
 
-                _AudioMode = (EAudioMode)_SelectSlides[_SelectSlideOptionsAudioMode].Selection;
+                _AudioMode = (EAudioMode)_SelectSlides[_SelectSlideOptionsAudioMode].SelectedTag;
                 _PlayerSelect = (EPlayerSelect)_SelectSlides[_SelectSlideOptionsPlayerSelect].Selection;
 
                 CGame.Reset();
@@ -1466,23 +1466,24 @@ namespace Vocaluxe.Screens
 
             if (currentSong.HasInstrumental() && currentSong.HasVocals())
             {
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL");
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL");
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS");
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE");
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL", tag: (int)EAudioMode.TR_AUDIOMODE_NORMAL);
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL", tag: (int)EAudioMode.TR_AUDIOMODE_INSTRUMENTAL);
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS", tag: (int)EAudioMode.TR_AUDIOMODE_VOCALS);
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
-            }
+            }    
             else if (currentSong.HasInstrumental())
             {
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL");
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL");
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE");
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL", tag: (int)EAudioMode.TR_AUDIOMODE_NORMAL);
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL", tag: (int)EAudioMode.TR_AUDIOMODE_INSTRUMENTAL);
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
             }
             else
             {
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = false;
             }
+
             _SelectSlides[_SelectSlideOptionsAudioMode].Selection = (int)_AudioMode;
 
             _SelectSlides[_SelectSlideOptionsPlayerSelect].Clear();

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -54,6 +54,10 @@ namespace Vocaluxe.Screens
         private const string _TextHelpBarSearch = "TextHelpBarSearch";
         private const string _TextHelpBarParty = "TextHelpBarParty";
         private const string _TextOptionsTitle = "TextOptionsTitle";
+        private const string _TextOptionsLength = "TextOptionsLength";
+        private const string _TextOptionsAudioMode = "TextOptionsAudioMode";
+        private const string _TextOptionsPlayerSelect = "TextOptionsPlayerSelect";
+        private const string _TextOptionsPlaylist = "TextOptionsPlaylist";
         private const string _TextShortInfoTop = "TextShortInfoTop";
 
         private const string _ButtonOpenOptions = "ButtonOpenOptions";
@@ -179,6 +183,11 @@ namespace Vocaluxe.Screens
             tlist.Add(_TextHelpBarSearch);
             tlist.Add(_TextHelpBarParty);
             tlist.Add(_TextOptionsTitle);
+            tlist.Add(_TextOptionsLength);
+            tlist.Add(_TextOptionsAudioMode);
+            tlist.Add(_TextOptionsPlayerSelect);
+            tlist.Add(_TextOptionsPlaylist);
+            
             tlist.Add(_TextShortInfoTop);
 
             _ThemeStatics = new string[] {_StaticSearchBar, _StaticOptionsBG, _StaticShortInfoTop};
@@ -1409,6 +1418,10 @@ namespace Vocaluxe.Screens
             _Buttons[_ButtonOptionsStartMedley].Visible = false;
             _Buttons[_ButtonOptionsHighscore].Visible = false;
             _Texts[_TextOptionsTitle].Visible = false;
+            _Texts[_TextOptionsLength].Visible = false;
+            _Texts[_TextOptionsAudioMode].Visible = false;
+            _Texts[_TextOptionsPlayerSelect].Visible = false;
+            _Texts[_TextOptionsPlaylist].Visible = false;
             _Statics[_StaticOptionsBG].Visible = false;
             _Buttons[_ButtonOpenOptions].Visible = true;
 
@@ -1426,6 +1439,9 @@ namespace Vocaluxe.Screens
             _UpdatePlaylistNames();
 
             _Texts[_TextOptionsTitle].Visible = true;
+            _Texts[_TextOptionsLength].Visible = true;
+            _Texts[_TextOptionsPlayerSelect].Visible = true;
+            _Texts[_TextOptionsPlaylist].Visible = true;
             _Buttons[_ButtonOptionsClose].Visible = true;
             _Statics[_StaticOptionsBG].Visible = true;
             _Buttons[_ButtonOpenOptions].Visible = false;
@@ -1471,6 +1487,7 @@ namespace Vocaluxe.Screens
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS", tag: (int)EAudioMode.TR_AUDIOMODE_VOCALS);
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
+                _Texts[_TextOptionsAudioMode].Visible = true;
             }    
             else if (currentSong.HasInstrumental())
             {
@@ -1478,10 +1495,12 @@ namespace Vocaluxe.Screens
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL", tag: (int)EAudioMode.TR_AUDIOMODE_INSTRUMENTAL);
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
+                _Texts[_TextOptionsAudioMode].Visible = true;
             }
             else
             {
                 _SelectSlides[_SelectSlideOptionsAudioMode].Visible = false;
+                _Texts[_TextOptionsAudioMode].Visible = false;
             }
 
             _SelectSlides[_SelectSlideOptionsAudioMode].Selection = (int)_AudioMode;

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -43,7 +43,7 @@ namespace Vocaluxe.Screens
         // Version number for theme files. Increment it, if you've changed something on the theme files!
         protected override int _ScreenVersion
         {
-            get { return 12; }
+            get { return 13; }
         }
 
         private const string _TextCategory = "TextCategory";

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1480,21 +1480,18 @@ namespace Vocaluxe.Screens
             _SelectSlides[_SelectSlideOptionsAudioMode].Clear();
             CSong currentSong = CSongs.VisibleSongs[_SongMenu.GetPreviewSongNr()];
 
-            if (currentSong.HasInstrumental() && currentSong.HasVocals())
+            if (currentSong.HasInstrumental())
             {
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL", tag: (int)EAudioMode.TR_AUDIOMODE_NORMAL);
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL", tag: (int)EAudioMode.TR_AUDIOMODE_INSTRUMENTAL);
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS", tag: (int)EAudioMode.TR_AUDIOMODE_VOCALS);
+				
+				if (currentSong.HasVocals())
+				{
+					_SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS", tag: (int)EAudioMode.TR_AUDIOMODE_VOCALS);
+				}
+				
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
-                _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
-                _Texts[_TextOptionsAudioMode].Visible = true;
-            }    
-            else if (currentSong.HasInstrumental())
-            {
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL", tag: (int)EAudioMode.TR_AUDIOMODE_NORMAL);
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL", tag: (int)EAudioMode.TR_AUDIOMODE_INSTRUMENTAL);
-                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE", tag: (int)EAudioMode.TR_AUDIOMODE_KARAOKE);
-                _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
+				_SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
                 _Texts[_TextOptionsAudioMode].Visible = true;
             }
             else

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -1463,7 +1463,16 @@ namespace Vocaluxe.Screens
 
             _SelectSlides[_SelectSlideOptionsAudioMode].Clear();
             CSong currentSong = CSongs.VisibleSongs[_SongMenu.GetPreviewSongNr()];
-            if (currentSong.HasInstrumental())
+
+            if (currentSong.HasInstrumental() && currentSong.HasVocals())
+            {
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL");
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL");
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_VOCALS");
+                _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_KARAOKE");
+                _SelectSlides[_SelectSlideOptionsAudioMode].Visible = true;
+            }
+            else if (currentSong.HasInstrumental())
             {
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_NORMAL");
                 _SelectSlides[_SelectSlideOptionsAudioMode].AddValue("TR_AUDIOMODE_INSTRUMENTAL");

--- a/VocaluxeLib/Enums.cs
+++ b/VocaluxeLib/Enums.cs
@@ -368,6 +368,7 @@ namespace VocaluxeLib
     {
         TR_AUDIOMODE_NORMAL,
         TR_AUDIOMODE_INSTRUMENTAL,
+        TR_AUDIOMODE_VOCALS,
         TR_AUDIOMODE_KARAOKE
     }
 

--- a/VocaluxeLib/Songs/CSong.cs
+++ b/VocaluxeLib/Songs/CSong.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -337,6 +337,11 @@ namespace VocaluxeLib.Songs
         public string GetVocals()
         {
             return Path.Combine(Folder, VocalsFileName);
+        }
+
+        public bool HasVocals()
+        {
+            return !string.IsNullOrEmpty(VocalsFileName);
         }
 
         public string GetVideo()


### PR DESCRIPTION
This introduces gameplay support for the vocals tag. (#627)

When a song includes both Instrumental and Vocal tags, a new Audio Mode option, "Instrumental/Vocal", becomes selectable. 
In this mode, the volume of the vocal track can be adjusted from the pause screen.

The new Audio Mode and volume slider are only visible when a song has both tags and the Instrumental/Vocal mode is selected. Otherwise, these controls remain hidden.

Additionally, headings have been added to the song options, making it easier for users to understand the different slider settings.