### PR TITLE
Bumped max count of filtered songs to 800

### DIFF
--- a/Vocaluxe/Base/CSongFilter.cs
+++ b/Vocaluxe/Base/CSongFilter.cs
@@ -191,8 +191,8 @@ namespace Vocaluxe.Base
                         _FilteredSongs.Add(song);
                     else if (expertSearch)
                     {
-                        // Stefan1200: Stop at a maximum of 500 search result to prevent performance issues
-                        if (_FilteredSongs.Count >= 500)
+                        // Stefan1200: Stop at a maximum of 800 search result to prevent performance issues
+                        if (_FilteredSongs.Count >= 800)
                             break;
 
                         if (searchForAlbum != null && song.Album.ToUpper().Contains(searchForAlbum))


### PR DESCRIPTION
I have 650 polish songs, currently list just cuts after 500th.

So I bumped max count of filtered songs to 800.
Runs fine with over 2500 songs on my 6GB RAM laptop.

It has already been bumped from 200 to 500 by Stefan1200-de 5 years ago.
