### PR TITLE
Fix server crashing due to an invalid username

### DIFF
--- a/Vocaluxe/Base/Server/CVocaluxeServer.cs
+++ b/Vocaluxe/Base/Server/CVocaluxeServer.cs
@@ -811,7 +811,7 @@ namespace Vocaluxe.Base.Server
         {
             CProfile profile = CProfiles.GetProfile(profileId);
             if (profile == null)
-                throw new ArgumentException("Invalid profileId");
+                return false;
 
             if (profile.PasswordHash == null)
             {
@@ -828,7 +828,7 @@ namespace Vocaluxe.Base.Server
         {
             CProfile profile = CProfiles.GetProfile(profileId);
             if (profile == null)
-                throw new ArgumentException("Invalid profileId");
+                return false;
 
             if (profile.PasswordHash == null)
             {
@@ -889,14 +889,7 @@ namespace Vocaluxe.Base.Server
             IEnumerable<Guid> playerIds = (from p in CProfiles.GetProfiles()
                                           where String.Equals(p.PlayerName, username, StringComparison.OrdinalIgnoreCase)
                                           select p.ID);
-            try
-            {
-                return playerIds.First();
-            }
-            catch (InvalidOperationException)
-            {
-                throw new ArgumentException("Invalid playername");
-            }
+            return playerIds.FirstOrDefault();
         }
 
         private static byte[] _Hash(byte[] password, byte[] salt)

--- a/Vocaluxe/Base/Server/CVocaluxeServer.cs
+++ b/Vocaluxe/Base/Server/CVocaluxeServer.cs
@@ -816,7 +816,7 @@ namespace Vocaluxe.Base.Server
             if (profile.PasswordHash == null)
             {
                 if (string.IsNullOrEmpty(password))
-                    return true; //Allow emty passwords
+                    return true; //Allow empty passwords
                 return false;
             }
 
@@ -833,7 +833,7 @@ namespace Vocaluxe.Base.Server
             if (profile.PasswordHash == null)
             {
                 if (hashedPassword == null)
-                    return true; //Allow emty passwords
+                    return true; //Allow empty passwords
                 return false;
             }
 
@@ -848,7 +848,7 @@ namespace Vocaluxe.Base.Server
                 throw new ArgumentException("Invalid profileId");
 
             if (profile.PasswordHash == null)
-                throw new ArgumentException("Emty password");
+                throw new ArgumentException("Empty password");
 
             return profile.PasswordSalt;
         }


### PR DESCRIPTION
Entering any invalid username on the web interface would crash the whole application by throwing an exception. This change will fix this by showing the default error message "Error..." instead. 
I think the web interface could be more user friendly if we used a Select input instead of Text input.