### PR TITLE
Fix for 2 build errors (non-blocking)

### DIFF
--- a/Tests/PartyModeChallenge/CPartyModeChallangeTest.cs
+++ b/Tests/PartyModeChallenge/CPartyModeChallangeTest.cs
@@ -1,4 +1,4 @@
-﻿#region license
+#region license
 // This file is part of Vocaluxe.
 // 
 // Vocaluxe is free software: you can redistribute it and/or modify
@@ -60,8 +60,8 @@ namespace Tests.PartyModeChallenge
                 CChallengeRounds rounds = new CChallengeRounds(numRounds, numPlayer, numMic);
                 Assert.IsTrue(rounds.Count >= numRounds);
                 _CheckRounds(rounds, numPlayer);
-                Warn.If(rounds.Count != numRounds,
-                    $"Number of rounds does not match. Expected: {numRounds}, Is: {rounds.Count} for {numPlayer}/{((numPlayer < numMic) ? numPlayer : numMic)}");
+                Assert.That(rounds.Count, Is.GreaterThanOrEqualTo(numRounds), 
+                    $"Number of rounds should be >= {numRounds}, is {rounds.Count} for {numPlayer}/{numMic}");
             }
         }
 

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -14,6 +14,10 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Tests/app.config
+++ b/Tests/app.config
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <startup>
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1" />
+  </startup>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog" publicKeyToken="24c2f752a8e58a10" culture="neutral" />
+        <bindingRedirect oldVersion="4.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Serilog.Enrichers.Thread" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>


### PR DESCRIPTION
### PartyModeChallenge
Constructor takes `numRounds` as upper limit, but dynamically generates more rounds until all players have sung equally often.  
Test expected exactly `numRounds`, but got "fair" amount.  
Test adapted to match actual logic.

### Serilog
NuGet restore installed Serilog 4.2.0, but manifest conflict (HRESULT 0x80131040).  
Added binding redirects
