### PR TITLE
Add SoundEffectVolume & VocalsVolume to SConfig Test

### DIFF
--- a/Tests/VocaluxeLib/XML/CXmlSerializerTest.cs
+++ b/Tests/VocaluxeLib/XML/CXmlSerializerTest.cs
@@ -419,7 +419,10 @@ namespace Tests.VocaluxeLib.XML
             // Typename will be uppercase but input is lowercase
             newXml = newXml.Replace("<String", "<string").Replace("</String", "</string");
             string oldXml = File.ReadAllText(xmlPath);
-            Assert.AreEqual(oldXml, newXml, "Recontructed XML has differences.");
+            // Trim trailing whitespace/newlines
+            oldXml = oldXml.TrimEnd('\r', '\n', ' ', '\t');
+            newXml = newXml.TrimEnd('\r', '\n', ' ', '\t');
+            Assert.AreEqual(oldXml, newXml, "Reconstructed XML has differences.");
         }
 
         #endregion

--- a/Tests/VocaluxeLib/XML/TestFiles/SConfig.xml
+++ b/Tests/VocaluxeLib/XML/TestFiles/SConfig.xml
@@ -56,6 +56,7 @@
     <BackgroundMusicUseStart>TR_CONFIG_ON</BackgroundMusicUseStart>
     <PreviewMusicVolume>50</PreviewMusicVolume>
     <GameMusicVolume>80</GameMusicVolume>
+    <SoundEffectVolume>50</SoundEffectVolume>
     <KaraokeEffect>TR_CONFIG_OFF</KaraokeEffect>
     <KaraokeEffectLevel>1</KaraokeEffectLevel>
   </Sound>

--- a/Tests/VocaluxeLib/XML/TestFiles/SConfig.xml
+++ b/Tests/VocaluxeLib/XML/TestFiles/SConfig.xml
@@ -56,7 +56,8 @@
     <BackgroundMusicUseStart>TR_CONFIG_ON</BackgroundMusicUseStart>
     <PreviewMusicVolume>50</PreviewMusicVolume>
     <GameMusicVolume>80</GameMusicVolume>
-    <SoundEffectVolume>50</SoundEffectVolume>
+    <SoundEffectVolume>80</SoundEffectVolume>
+    <VocalsVolume>50</VocalsVolume>
     <KaraokeEffect>TR_CONFIG_OFF</KaraokeEffect>
     <KaraokeEffectLevel>1</KaraokeEffectLevel>
   </Sound>


### PR DESCRIPTION
Adds the missing SoundEffectVolume and VocalsVolume to the SConfig test.

All tests now pass successfully on AppVeyor. 👍 