### PR TITLE
Song search field improvement

### DIFF
--- a/Output/Languages/en.xml
+++ b/Output/Languages/en.xml
@@ -155,7 +155,7 @@
   <string name="TR_SCREENSONG_PLAYERSELECT">Player selection</string>
   <string name="TR_SCREENSONG_PLAYERSELECT_ON">Show player selection</string>
   <string name="TR_SCREENSONG_PLAYERSELECT_OFF">Skip player selection</string>  
-  <string name="TR_SCREENSONG_SEARCH">Search:</string>
+  <string name="TR_SCREENSONG_SEARCH">Search song</string>
   <string name="TR_SCREENSONG_NOLANGUAGE">No language</string>
   <string name="TR_SCREENSONG_NOYEAR">No Year</string>
   <string name="TR_SCREENSONG_NOGENRE">No Genre</string>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -219,9 +219,9 @@
     </Text>
     <Text Name="TextSearchBarTitle">
       <X>355</X>
-      <Y>918</Y>
+      <Y>923</Y>
       <Z>0</Z>
-      <H>40.5</H>
+      <H>30.5</H>
       <MaxW>0</MaxW>
       <Color Name="ButtonTextColor" />
       <SelColor Name="ButtonTextSelColor" />

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -218,13 +218,13 @@
       </Reflection>
     </Text>
     <Text Name="TextSearchBarTitle">
-      <X>150</X>
+      <X>355</X>
       <Y>918</Y>
       <Z>0</Z>
       <H>40.5</H>
       <MaxW>0</MaxW>
-      <Color Name="Invisible" />
-      <SelColor Name="TextSelColor" />
+      <Color Name="ButtonTextColor" />
+      <SelColor Name="ButtonTextSelColor" />
       <Align>Right</Align>
       <ResizeAlign>Center</ResizeAlign>
       <Style>Bold</Style>

--- a/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
+++ b/Output/Themes/Vocaluxe 2024/Screens/ScreenSong.xml
@@ -225,7 +225,7 @@
       <MaxW>0</MaxW>
       <Color Name="ButtonTextColor" />
       <SelColor Name="ButtonTextSelColor" />
-      <Align>Right</Align>
+      <Align>Center</Align>
       <ResizeAlign>Center</ResizeAlign>
       <Style>Bold</Style>
       <Font>Outline</Font>

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -517,7 +517,7 @@ namespace Vocaluxe.Screens
         {
             base.HandleMouse(mouseEvent);
 
-			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
+			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent) && !_Sso.Selection.PartyMode;
 			_Texts[_TextSearchBarTitle].Selected = overSearchBar;
 
 			if (mouseEvent.LB && overSearchBar)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -520,11 +520,11 @@ namespace Vocaluxe.Screens
 			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
 			_Texts[_TextSearchBarTitle].Selected = overSearchBar;
 
-			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
+			if (mouseEvent.LB && overSearchBar)
 			{
 			    if (_SearchActive)
 			    {
-			        _SearchActive = false;
+ 			        _SearchActive = false;
 			        _SearchText = String.Empty;
 			        _ApplyNewSearchFilter(_SearchText);
 			    }

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -517,6 +517,9 @@ namespace Vocaluxe.Screens
         {
             base.HandleMouse(mouseEvent);
 
+			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
+			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CThemeColors.GetColor("ButtonTextSelColor") : CThemeColors.GetColor("ButtonTextColor");
+
 			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{
 			    if (_SearchActive)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -517,6 +517,21 @@ namespace Vocaluxe.Screens
         {
             base.HandleMouse(mouseEvent);
 
+			if (mouseEvent.LB && Statics[StaticSearchBar].Visible && CHelper.IsInBounds(Statics[StaticSearchBar].Rect, mouseEvent))
+			{
+                if (SearchActive)
+                    {
+                       SearchActive = false;
+                       SearchText = String.Empty;
+                       ApplyNewSearchFilter(SearchText);
+                    }
+                else if (!Sso.Selection.PartyMode)
+                    {
+                       SearchActive = true;
+                    }
+                return true;
+			}
+
             if (_DragAndDropCover.Visible)
             {
                 _DragAndDropCover.X += mouseEvent.X - _OldMousePosX;

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -875,7 +875,7 @@ namespace Vocaluxe.Screens
             else
             {
                 _Texts[_TextSearchBar].Visible = false;
-                _Texts[_TextSearchBarTitle].Visible = true;
+                _Texts[_TextSearchBarTitle].Visible = !_Sso.Selection.PartyMode;
                 _Texts[_TextHelpBar].Visible = !_Sso.Selection.PartyMode;
                 _Texts[_TextHelpBarSearch].Visible = false;
                 _Texts[_TextHelpBarParty].Visible = _Sso.Selection.PartyMode;
@@ -1439,7 +1439,7 @@ namespace Vocaluxe.Screens
             _Texts[_TextOptionsPlayerSelect].Visible = false;
             _Texts[_TextOptionsPlaylist].Visible = false;
             _Statics[_StaticOptionsBG].Visible = false;
-			_Statics[_StaticSearchBar].Visible = true;
+			_Statics[_StaticSearchBar].Visible = !_Sso.Selection.PartyMode;
             _Buttons[_ButtonOpenOptions].Visible = true;
 
             if (view == ESongOptionsView.None)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -517,17 +517,17 @@ namespace Vocaluxe.Screens
         {
             base.HandleMouse(mouseEvent);
 
-			if (mouseEvent.LB && Statics[StaticSearchBar].Visible && CHelper.IsInBounds(Statics[StaticSearchBar].Rect, mouseEvent))
+			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{
-			    if (SearchActive)
+			    if (_SearchActive)
 			    {
-			        SearchActive = false;
-			        SearchText = String.Empty;
-			        ApplyNewSearchFilter(SearchText);
+			        _SearchActive = false;
+			        _SearchText = String.Empty;
+			        _ApplyNewSearchFilter(_SearchText);
 			    }
-			    else if (!Sso.Selection.PartyMode)
+			    else if (!_Sso.Selection.PartyMode)
 			    {
-			        SearchActive = true;
+			        _SearchActive = true;
 			    }
 			    return true;
 			}

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -853,7 +853,6 @@ namespace Vocaluxe.Screens
                 _Texts[_TextHelpBar].Visible = false;
                 _Texts[_TextHelpBarSearch].Visible = true;
                 _Texts[_TextHelpBarParty].Visible = false;
-                _Statics[_StaticSearchBar].Visible = true;
             }
             else
             {
@@ -862,7 +861,6 @@ namespace Vocaluxe.Screens
                 _Texts[_TextHelpBar].Visible = !_Sso.Selection.PartyMode;
                 _Texts[_TextHelpBarSearch].Visible = false;
                 _Texts[_TextHelpBarParty].Visible = _Sso.Selection.PartyMode;
-                _Statics[_StaticSearchBar].Visible = false;
             }
 
             _UpdatePartyModeOptions();
@@ -1423,6 +1421,7 @@ namespace Vocaluxe.Screens
             _Texts[_TextOptionsPlayerSelect].Visible = false;
             _Texts[_TextOptionsPlaylist].Visible = false;
             _Statics[_StaticOptionsBG].Visible = false;
+			_Statics[_StaticSearchBar].Visible = true;
             _Buttons[_ButtonOpenOptions].Visible = true;
 
             if (view == ESongOptionsView.None)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -518,7 +518,7 @@ namespace Vocaluxe.Screens
             base.HandleMouse(mouseEvent);
 
 			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
-			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CThemeColors.GetColor("ButtonTextSelColor") : CThemeColors.GetColor("ButtonTextColor");
+			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CTheme.GetColor("ButtonTextSelColor") : CTheme.GetColor("ButtonTextColor");
 
 			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -518,10 +518,7 @@ namespace Vocaluxe.Screens
             base.HandleMouse(mouseEvent);
 
 			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
-			SColorF selColor, normalColor;
-			CThemes.GetColor("ButtonTextSelColor", -1, out selColor);
-			CThemes.GetColor("ButtonTextColor", -1, out normalColor);
-			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? selColor : normalColor;
+			_Texts[_TextSearchBarTitle].Selected = overSearchBar;
 
 			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -518,7 +518,7 @@ namespace Vocaluxe.Screens
             base.HandleMouse(mouseEvent);
 
 			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
-			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CTheme.GetColor("ButtonTextSelColor") : CTheme.GetColor("ButtonTextColor");
+			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CThemes.GetColor("ButtonTextSelColor") : CThemes.GetColor("ButtonTextColor");
 
 			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -518,7 +518,10 @@ namespace Vocaluxe.Screens
             base.HandleMouse(mouseEvent);
 
 			bool overSearchBar = _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent);
-			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? CThemes.GetColor("ButtonTextSelColor") : CThemes.GetColor("ButtonTextColor");
+			SColorF selColor, normalColor;
+			CThemes.GetColor("ButtonTextSelColor", -1, out selColor);
+			CThemes.GetColor("ButtonTextColor", -1, out normalColor);
+			_Texts[_TextSearchBarTitle].SelColor = overSearchBar ? selColor : normalColor;
 
 			if (mouseEvent.LB && _Statics[_StaticSearchBar].Visible && CHelper.IsInBounds(_Statics[_StaticSearchBar].Rect, mouseEvent))
 			{

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -519,17 +519,17 @@ namespace Vocaluxe.Screens
 
 			if (mouseEvent.LB && Statics[StaticSearchBar].Visible && CHelper.IsInBounds(Statics[StaticSearchBar].Rect, mouseEvent))
 			{
-                if (SearchActive)
-                    {
-                       SearchActive = false;
-                       SearchText = String.Empty;
-                       ApplyNewSearchFilter(SearchText);
-                    }
-                else if (!Sso.Selection.PartyMode)
-                    {
-                       SearchActive = true;
-                    }
-                return true;
+			    if (SearchActive)
+			    {
+			        SearchActive = false;
+			        SearchText = String.Empty;
+			        ApplyNewSearchFilter(SearchText);
+			    }
+			    else if (!Sso.Selection.PartyMode)
+			    {
+			        SearchActive = true;
+			    }
+			    return true;
 			}
 
             if (_DragAndDropCover.Visible)

--- a/Vocaluxe/Screens/CScreenSong.cs
+++ b/Vocaluxe/Screens/CScreenSong.cs
@@ -849,7 +849,7 @@ namespace Vocaluxe.Screens
                 _Texts[_TextSearchBar].Text += '|';
 
                 _Texts[_TextSearchBar].Visible = true;
-                _Texts[_TextSearchBarTitle].Visible = true;
+                _Texts[_TextSearchBarTitle].Visible = false;
                 _Texts[_TextHelpBar].Visible = false;
                 _Texts[_TextHelpBarSearch].Visible = true;
                 _Texts[_TextHelpBarParty].Visible = false;
@@ -857,7 +857,7 @@ namespace Vocaluxe.Screens
             else
             {
                 _Texts[_TextSearchBar].Visible = false;
-                _Texts[_TextSearchBarTitle].Visible = false;
+                _Texts[_TextSearchBarTitle].Visible = true;
                 _Texts[_TextHelpBar].Visible = !_Sso.Selection.PartyMode;
                 _Texts[_TextHelpBarSearch].Visible = false;
                 _Texts[_TextHelpBarParty].Visible = _Sso.Selection.PartyMode;


### PR DESCRIPTION
The song search on the Song screen was previously only accessible by pressing F3. It can now also be activated by clicking on the search field.

Additionally, the search field used to appear completely empty until F3 was pressed. It now displays a search icon and placeholder text by default, making it more visible to the user.