### PR TITLE
Add check for VC++ 2015–2022 Redistributable

### DIFF
--- a/Output/Readme.txt
+++ b/Output/Readme.txt
@@ -23,10 +23,10 @@ Vocaluxe is an entirely new development in C#, inspired by the original UltraSta
 and the great Ultrastar Deluxe project.
 
 Supported Operating Systems / Requirements:
-- Windows Vista, Windows 7, Windows 8, Windows 10 or Windows 11 with .NET 4.0
+- Windows 7, Windows 8, Windows 8.1, Windows 10 and Windows 11 with .NET 4.0
 - Linux (no official support)
 - 1 GHz CPU, 512 MB RAM, Graphics card with OpenGL 2.1 or DirectX 9.0 support
-- Visual C++ Redistributable Package 2010 (2015-2022 is required for the nightly builds)
+- Visual C++ Redistributable Package 2010 (Nightly builds additionally require VC++ 2015–2022)
 
 
 =================================
@@ -176,7 +176,7 @@ Vocaluxe Homepage:		https://vocaluxe.org
 Bug Tracker:			https://github.com/Vocaluxe/Vocaluxe/issues
 Translations:			https://www.transifex.com/projects/p/vocaluxe/
 GitHub Wiki:			https://github.com/Vocaluxe/Vocaluxe/wiki
-Song-DataBase (USDB):		http://usdb.animux.de/
+Song-DataBase (USDB):	http://usdb.animux.de/
 
 
 =================================

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ It features mouse, keyboard, gamepad and Wiimote navigation, a multi-language in
 Vocaluxe offers diversified party modes and can optionally be controlled via a browser (desktop and mobile supported).
 
 Supported Operating Systems / Requirements:
-- Windows Vista, Windows 7, Windows 8, Windows 8.1, Windows 10 and Windows 11 with .NET 4.0
+- Windows 7, Windows 8, Windows 8.1, Windows 10 and Windows 11 with .NET 4.0
 - *Linux* (no official support)
 - 1 GHz CPU, 512 MB RAM, Graphics card with OpenGL 2.1 or DirectX 9.0 support
-- Visual C++ Redistributable Package 2010 (2015-2022 is required for the nightly builds)
+- Visual C++ Redistributable Package 2010 (Nightly builds additionally require VC++ 2015–2022)
 
 
 ## 2. Download

--- a/Vocaluxe/CProgrammHelper.cs
+++ b/Vocaluxe/CProgrammHelper.cs
@@ -81,20 +81,49 @@ namespace Vocaluxe
             return File.Exists(Environment.ExpandEnvironmentVariables(sysDir + dllName + ".dll"));
         }
 
-        private static bool _IsVC2012Installed()
-        {
-            return _SystemDllExists("msvcr110") && _SystemDllExists("msvcp110");
-        }
-
-        private static bool _IsVC2008Installed()
-        {
-            return _IsProgramInstalled("Microsoft Visual C++ 2008 Redistributable");
-        }
-
         private static bool _IsVC2010Installed()
         {
             //Note: Maybe check for x64 or x86
             return _IsProgramInstalled("Microsoft Visual C++ 2010");
+        }
+
+        private static bool _IsVC2015To2022Installed()
+        {
+            const string baseKey = @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\";
+            const string wow6432BaseKey = @"SOFTWARE\Wow6432Node\Microsoft\VisualStudio\14.0\VC\Runtimes\";
+
+        #if ARCH_X64
+            string[] arches = { "x64" };
+        #elif ARCH_X86
+            string[] arches = { "x86" };
+        #else
+            string[] arches = { "x86", "x64" };
+        #endif
+
+            foreach (string arch in arches)
+            {
+                using (RegistryKey rk = Registry.LocalMachine.OpenSubKey(baseKey + arch) ??
+                                        Registry.LocalMachine.OpenSubKey(wow6432BaseKey + arch))
+                {
+                    if (rk == null)
+                        continue;
+
+                    object installed = rk.GetValue("Installed");
+                    if (installed == null)
+                        continue;
+
+                    try
+                    {
+                        if (Convert.ToInt32(installed) == 1)
+                            return true;
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+
+            return false;
         }
 
         private static void _EnsureDataFolderExists()
@@ -123,26 +152,16 @@ namespace Vocaluxe
                     "VC++ 2010 Redistributables are missing. Please install them first.\r\nDownload: https://www.microsoft.com/download/details.aspx?id=26999");
                 return false;
             }
-            /*
-            if (!_IsVC2012Installed())
-            {
-                CLog.Fatal(
-                    "VC++ 2012 Redistributables are missing. Please install them first.\r\nDownload: http://www.microsoft.com/de-de/download/details.aspx?id=30679");
-                return false;
-            }
-            bool vc2008Installed = _IsVC2008Installed();
-            if (!vc2008Installed)
-            {
-                CLog.Fatal(
-                    "VC++ 2008 Redistributables are missing. Portaudio might not be working.\r\nDownload: http://www.microsoft.com/de-de/download/details.aspx?id=29");
-            }
-            if (!vc2008Installed && !_IsVC2010Installed())
-            {
-                CLog.Fatal(
-                    "VC++ 2010 and 2008 Redistributables are missing. Please install them first. VC++ 2008 is preferred as Portaudio doesn't work with VC++ 2010.\r\nDownload(2008): http://www.microsoft.com/de-de/download/details.aspx?id=29 \r\nDownload(2010): http://www.microsoft.com/de-de/download/details.aspx?id=5555");
-                return false;
-            }
-            */
+
+            if (!_IsVC2015To2022Installed())
+                {
+                    CLog.Fatal(
+                        "VC++ 2015-2022 Redistributables are missing. Please install them first.\r\n" +
+                        "Download x64: https://aka.ms/vc14/vc_redist.x64.exe\r\n" +
+                        "Download x86: https://aka.ms/vc14/vc_redist.x86.exe");
+                    return false;
+                }
+
 #endif //TODO: check for dependencies on linux?
             return true;
         }

--- a/Vocaluxe/CProgrammHelper.cs
+++ b/Vocaluxe/CProgrammHelper.cs
@@ -75,12 +75,6 @@ namespace Vocaluxe
             return _CheckUninstallKey(name, baseKey + uninstallKey) || (_KeyExists(baseKey64) && _CheckUninstallKey(name, baseKey64 + uninstallKey));
         }
 
-        private static bool _SystemDllExists(string dllName)
-        {
-            const string sysDir = "%windir%\\system32\\";
-            return File.Exists(Environment.ExpandEnvironmentVariables(sysDir + dllName + ".dll"));
-        }
-
         private static bool _IsVC2010Installed()
         {
             //Note: Maybe check for x64 or x86

--- a/Vocaluxe/CProgrammHelper.cs
+++ b/Vocaluxe/CProgrammHelper.cs
@@ -100,30 +100,25 @@ namespace Vocaluxe
             string[] arches = { "x86", "x64" };
         #endif
 
-            foreach (string arch in arches)
+        foreach (string arch in arches)
+        {
+            using (RegistryKey rk = Registry.LocalMachine.OpenSubKey(baseKey + arch) ??
+                                    Registry.LocalMachine.OpenSubKey(wow6432BaseKey + arch))
             {
-                using (RegistryKey rk = Registry.LocalMachine.OpenSubKey(baseKey + arch) ??
-                                        Registry.LocalMachine.OpenSubKey(wow6432BaseKey + arch))
-                {
-                    if (rk == null)
-                        continue;
+                if (rk == null)
+                    continue;
 
-                    object installed = rk.GetValue("Installed");
-                    if (installed == null)
-                        continue;
+                object installed = rk.GetValue("Installed");
+                if (installed == null)
+                    continue;
 
-                    try
-                    {
-                        if (Convert.ToInt32(installed) == 1)
-                            return true;
-                    }
-                    catch
-                    {
-                    }
-                }
+                int installedValue;
+                if (int.TryParse(installed.ToString(), out installedValue) && installedValue == 1)
+                    return true;
             }
+        }
 
-            return false;
+        return false;
         }
 
         private static void _EnsureDataFolderExists()


### PR DESCRIPTION
At the moment, the application only checks for the VC++ 2010 Redistributable at startup. If the VC++ 2015–2022 Redistributable is missing, startup fails with the misleading error message "Error while reading "ScreenMain".xml".

This adds an explicit check for the VC++ 2015–2022 Redistributable and shows a clear error message with the official Microsoft download links when it is not installed. (The existing VC++ 2010 check remains unchanged)

The Readme was also updated:
Windows Vista was removed because VC++ 2015–2022 redistributable officially only support Windows 7 and up.
In addition, the VC++ requirements were reworded to make it clearer that the VC++ 2015–2022 Redistributable is required in addition to VC++ 2010 for nightly builds, rather than replacing it. (2010 is still needed for SlimDX).