### PR TITLE
Fix crash and wrong device names in the DirectSound record backend

### DIFF
--- a/Vocaluxe/Lib/Sound/Record/DirectSound/CDirectSoundRecord.cs
+++ b/Vocaluxe/Lib/Sound/Record/DirectSound/CDirectSoundRecord.cs
@@ -42,7 +42,7 @@ namespace Vocaluxe.Lib.Sound.Record.DirectSound
             {
                 using (var ds = new DirectSoundCapture(dev.DriverGuid))
                 {
-                    var device = new CRecordDevice(_Devices.Count, dev.DriverGuid.ToString(), dev.Description, ds.Capabilities.Channels);
+                    var device = new CRecordDevice(_Devices.Count, dev.Description, dev.DriverGuid.ToString(), ds.Capabilities.Channels);
 
                     _Devices.Add(device);
                 }


### PR DESCRIPTION
Fixes #887.

`CDirectSoundRecord` passed the GUID and the description to `CRecordDevice` in the wrong order, so `Name` ended up holding the driver GUID and `Driver` the description. That made the device list show GUIDs, and `CSoundCardSource` then tried to parse the description as a `Guid`, which threw and killed the process as soon as a microphone was assigned.

This swaps the two arguments to match the constructor signature `(id, name, driver, channels)`.

One caveat: it changes what gets persisted to `Config.xml` under `Record/MicConfig/DeviceName` and `DeviceDriver`, so existing configs won't match any more and users have to pick their microphone once. Given the backend crashes today that seemed like the lesser problem, but it may deserve a line in the release notes.

I opened this against `develop` as a stopgap. #881 removes the DirectSound backend entirely, so feel free to close this if you'd rather wait for that.
